### PR TITLE
Correctly fix the gcc version detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
   # Some "no-warning" flags are not supported with gcc < 4.0
   if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     exec_program(gcc ARGS --version OUTPUT_VARIABLE CMAKE_C_COMPILER_VERSION)
-    if(NOT CMAKE_C_COMPILER_VERSION MATCHES ".*[0-3]\\.[0-9].*")
+    if(NOT CMAKE_C_COMPILER_VERSION MATCHES "(^|[^\\.])[0-3]\\.[0-9]")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-fatal-errors -Wno-extra")
     endif()
   else()


### PR DESCRIPTION
Make sure that the major and minor number never be confused.

Sorry for the double patch :/
