### PR TITLE
Remove useless workarounds and use color-mapped custom blits

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -160,20 +160,6 @@
 #endif
 
 /**
- * \def SOLARUS_FULLSCREEN_FORCE_OK
- * \brief Define if the current platform should force all fullscreen mode to be available.
- * If set to 1, VideoManager::is_mode_supported() may not call SDL_VideoModeOK()
- */
-#ifndef SOLARUS_FULLSCREEN_FORCE_OK
-#  if defined(SOLARUS_OSX)
-// Since OSX 10.7, SDL_VideoModeOK() always return 0 with SDL_FULLSCREEN flag
-#    define SOLARUS_FULLSCREEN_FORCE_OK 1
-#  else
-#    define SOLARUS_FULLSCREEN_FORCE_OK 0
-#  endif
-#endif
-
-/**
  * \def SOLARUS_SCREEN_DOUBLEBUF
  * \brief Define if the current platform supports double buffering.
  */
@@ -182,21 +168,6 @@
 #    define SOLARUS_SCREEN_DOUBLEBUF 0
 #  else
 #    define SOLARUS_SCREEN_DOUBLEBUF 1
-#  endif
-#endif
-
-/**
- * \def SOLARUS_SCREEN_DOUBLEBUF
- * \brief Define to render the screen on an intermediate surface
- * (workaround to rendering issues in fullscreen).
- *
- * Don't define this if you have no problem.
- */
-#ifndef SOLARUS_SCREEN_INTERMEDIATE_SURFACE
-#  if defined(__APPLE__)
-#    define SOLARUS_SCREEN_INTERMEDIATE_SURFACE 0
-#  else
-#    define SOLARUS_SCREEN_INTERMEDIATE_SURFACE 1
 #  endif
 #endif
 

--- a/include/lowlevel/Surface.h
+++ b/include/lowlevel/Surface.h
@@ -89,8 +89,8 @@ class Surface: public Drawable {
     bool internal_surface_created;               /**< indicates that internal_surface was allocated from this class */
 
     uint32_t get_pixel32(int idx_pixel);
-    SDL_Surface* get_internal_surface();
     uint32_t get_mapped_pixel(int idx_pixel, SDL_PixelFormat* dst_format);
+    SDL_Surface* get_internal_surface();
 };
 
 #endif

--- a/include/lowlevel/VideoManager.h
+++ b/include/lowlevel/VideoManager.h
@@ -106,9 +106,7 @@ class VideoManager {
                                              * video mode with the current quest size. */
 
     VideoMode video_mode;                   /**< Current video mode of the screen. */
-    Surface* screen_surface;                /**< The screen surface. */
-    Surface* intermediate_screen_surface;   /**< An intermediate surface to use for pixel operations
-                                             * when SOLARUS_SCREEN_INTERMEDIATE_SURFACE is on. */
+    Surface* screen_surface;                /**< The screen surface. */\
 
     int enlargment_factor;                  /**< 1 if the quest surface it not stretched or scaled,
                                              * 2 if it is stretched or scaled by a factor of 2. */


### PR DESCRIPTION
The final behavior is exactely the same with and without this patch.

As excepted, the only drawback of the new video system is that the display won't be optimal stretched if resolution is much more than 2 \* quest_size.

For exemple on my OSX 10.6, fullscreen modes fill the entiere height and have a little x_offset (because of the 16:10 format, perfectly normal).
But on OSX 10.7, because of the low-resolution abandonment, the display is 640x320 centered on 1024x768 screen, as you said here https://github.com/christopho/solarus/commit/2dfccc74e11c13a4fb4c6971e7879b73dd44ca83

I really think that a feature capable to stretch from any quest_mode size to any resolution size (keeping the same proportionality between each length) is a good idea. Maybe protected by something like a SOLARUS_LINEAR_INTERPOLATION_BLIT flag ?

EDIT: Lelinuxien's report : 
"Le mode large est identique au non large. Sous Windows, j'ai des bords noirs tout autour pour le mode large et le mode plein écran étiré normal n'a aucun bord noir (le jeu occupe tout l'écran).  
Large ou non large, c'est effectivement du 640x480 centré avec du noir tout autour."
