### PR TITLE
Fix includes for OpenBSD.

### DIFF
--- a/src/lowlevel/ItDecoder.cpp
+++ b/src/lowlevel/ItDecoder.cpp
@@ -17,8 +17,14 @@
 #include "lowlevel/ItDecoder.h"
 #include "lowlevel/Debug.h"
 #include "lowlevel/StringConcat.h"
+
+#if defined(__OpenBSD__)
+#include <libmodplug/stdafx.h>  // OpenBSD puts these in a different location.
+#include <libmodplug/sndfile.h>
+#else
 #include <stdafx.h>  // These two headers are with the libmodplug ones.
 #include <sndfile.h>
+#endif
 
 /**
  * \brief Creates an Impulse Tracker decoder.


### PR DESCRIPTION
I had gotten thrown off because we already have a sndfile.h in /usr/local/include that's _different_ from the sndfile.h in /usr/local/include/libmodplug (go figure...)

OpenBSD wants the sndfile.h in /usr/local/include/libmodplug/
