### PR TITLE
Fix unintentional humor.

### DIFF
--- a/sample_quest/data/languages/en/text/dialogs.dat
+++ b/sample_quest/data/languages/en/text/dialogs.dat
@@ -3,7 +3,8 @@ dialog{
   text = [[
 You found some Bombs!
 Press X to drop a bomb
-and blow everything!
+and blow everything
+up!
 ]]
 }
 


### PR DESCRIPTION
This is grammatically correct. The original phrase can be misinterpreted in a variety of ways.
