### PR TITLE
Fix issue #440: When changing the id or the name, set the old value in t...

### DIFF
--- a/tools/editor/src/main/java/org/solarus/editor/gui/EditorWindow.java
+++ b/tools/editor/src/main/java/org/solarus/editor/gui/EditorWindow.java
@@ -884,11 +884,11 @@ public class EditorWindow extends JFrame
         String resourceName = resourceType.getName();
         String resourceNameLower = resourceName.toLowerCase();
         try {
-            String newId = JOptionPane.showInputDialog(
+            String newId = (String) JOptionPane.showInputDialog(
                     null,
                     "Please enter a new id for " + resourceNameLower + " '" + oldId + "'",
                     "Change id of " + resourceNameLower + " '" + oldId + "'",
-                    JOptionPane.QUESTION_MESSAGE);
+                    JOptionPane.QUESTION_MESSAGE, null, null, oldId);
 
             if (newId != null) {
                 if (Project.getResource(resourceType).exists(newId)) {
@@ -917,11 +917,11 @@ public class EditorWindow extends JFrame
         String resourceNameLower = resourceName.toLowerCase();
         try {
             String oldName = resource.getElementName(id);
-            String newName = JOptionPane.showInputDialog(
+            String newName = (String) JOptionPane.showInputDialog(
                     null,
                     "Please enter a new name for '" + oldName + "'",
                     "Rename " + resourceNameLower + " '" + oldName + "'",
-                    JOptionPane.QUESTION_MESSAGE);
+                    JOptionPane.QUESTION_MESSAGE, null, null, oldName);
 
             if (newName != null) {
                 Project.renameResourceElement(resourceType, id, newName);


### PR DESCRIPTION
#440:

In the quest tree on the left of the window, you can right-click a resource (for example a map) and then change its id or its name.
When changing the id or the name, the current value should initially appear in the dialog box.
