### PR TITLE
Modernize AppleInterface

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -92,16 +92,6 @@
  */
 
 /**
- * \def SOLARUS_USE_APPLE_POOL
- * \brief Set if Obj-C pool have to be in place.
- */
-#ifndef SOLARUS_USE_APPLE_POOL
-#  if defined(__APPLE__)
-#    define SOLARUS_USE_APPLE_POOL
-#  endif
-#endif
-
-/**
  * \def SOLARUS_HAVE_OPENGL
  * \brief Whether the system supports OpenGL as renderer driver.
  * This is optional, but allows to use advanced display features.

--- a/include/lowlevel/apple/AppleInterface.h
+++ b/include/lowlevel/apple/AppleInterface.h
@@ -18,14 +18,13 @@
 #define __APPLEINTERFACE_H__
 
 #include "Common.h"
+#include <string>
 
-#if defined(SOLARUS_OSX)
+#if defined(SOLARUS_OSX) || defined(SOLARUS_IOS)
 
-// This are C "trampoline" function that will be used
-// to invoke a specific Objective-C method FROM C++
-void init_pool();
-void drain_pool();
-const char* get_user_application_support_directory();
+// This are C++ "trampoline" function that will be used
+// to invoke a specific Objective-C method from C++.
+std::string get_user_application_support_directory();
 
 #endif
 

--- a/src/lowlevel/System.cpp
+++ b/src/lowlevel/System.cpp
@@ -42,11 +42,6 @@ uint32_t System::ticks = 0;
  */
 void System::initialize(const CommandLine& args) {
 
-#ifdef SOLARUS_USE_APPLE_POOL
-  // initialize pool if any
-  init_pool();
-#endif
-
   // initialize SDL
   SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK);
 
@@ -86,9 +81,6 @@ void System::quit() {
   FileTools::quit();
 
   SDL_Quit();
-#ifdef SOLARUS_USE_APPLE_POOL
-  drain_pool();
-#endif
 }
 
 /**

--- a/src/lowlevel/apple/AppleInterface.mm
+++ b/src/lowlevel/apple/AppleInterface.mm
@@ -16,7 +16,7 @@
  */
 #include <lowlevel/apple/AppleInterface.h>
 
-#if defined(SOLARUS_OSX)
+#if defined(SOLARUS_OSX) || defined(SOLARUS_IOS)
 
 #if defined(SOLARUS_OSX)
 #  import <Cocoa/Cocoa.h>
@@ -26,51 +26,29 @@
 #endif
 
 
-NSAutoreleasePool* solarus_pool = nil;
-
-/**
- * @brief Initialize and allocate the NSAutoreleasePool object.
- *
- * Allow to use the Cocoa's reference-counted memory management system on Cocoa objects.
- */
-void init_pool()
-{
-    if (solarus_pool == nil)
-        solarus_pool = [[NSAutoreleasePool alloc] init];
-}
-
-/**
- * @brief Drain the NSAutoreleasePool object.
- */
-void drain_pool()
-{
-    if (solarus_pool)
-        [solarus_pool drain];
-}
-
 /**
  * @brief Return "~/Library/Application Support" or equivalent from the official way, which is available in OSX 10.6+ and iOS 4.0+.
  *
  * Return an OSX 10.0+ and iOS 1.0+ (not compatible with Iphone Simulator) hardcoded equivalent workaround if the 
  * build configuration is set for a lower minimum version.
- *
  * @return The Application Support folder from the User Domain.
  */
-const char* get_user_application_support_directory()
+std::string get_user_application_support_directory()
 {
+  @autoreleasepool {
+
 #if defined(SOLARUS_OSX) && __MAC_OS_X_VERSION_MIN_REQUIRED  >= MAC_OS_X_VERSION_10_6 \
- || defined(SOLARUS_IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
-    return [[[[[NSFileManager defaultManager] 
-               URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] 
-              objectAtIndex:0] 
-             path] 
+|| defined(SOLARUS_IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+    return [[[[[NSFileManager defaultManager]
+               URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask]
+              objectAtIndex:0]
+             path]
             UTF8String];
 #else
-    // WORKAROUND : Avoid to report errors with undefined enum, and warning with undefined functions.
-    // ( enum NSApplicationSupportDirectory and NSUserDomainMask are not defined on older OSX frameworks )
-    return [[NSHomeDirectory() stringByAppendingPathComponent:@"Library/Application Support"] 
+    return [[NSHomeDirectory() stringByAppendingPathComponent:@"Library/Application Support"]
             UTF8String];
 #endif
+  }
 }
 
 #endif


### PR DESCRIPTION
Use Objective-C++ functions and @autoreleasepool instead of manually setting a pool.
It allow to build Solarus on iOS natively (at least by copying source files into a new XCode iOS project, I didn't tried to generate the full iOS project with cmake for now, even if it should works).
The modernization was needed because of the new ARC system with Obj-C objects, which wasn't supported before since the NSAutoReleasePool was explictely used.
