### PR TITLE
Explicitly deleted MapEntity copy constructor and operator.

### DIFF
--- a/include/entities/MapEntity.h
+++ b/include/entities/MapEntity.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -286,6 +286,10 @@ class MapEntity: public ExportableToLua {
         int height
     );
 
+    // No copy constructor or assignment operator.
+    MapEntity(const MapEntity& other) = delete;
+    MapEntity& operator=(const MapEntity& other) = delete;
+
     uint32_t get_when_suspended() const;
 
     void update_ground_observers();
@@ -303,10 +307,6 @@ class MapEntity: public ExportableToLua {
     Hero& get_hero();
 
   private:
-
-    // No copy constructor or assignment operator.
-    MapEntity(const MapEntity& other);
-    MapEntity& operator=(const MapEntity& other);
 
     void finish_initialization();
     void clear_old_movements();


### PR DESCRIPTION
Writing "= delete" after the functions we don't want to be generated is the new prefered way to explcitly delete such a function, considered better than making it private.
