### PR TITLE
Removed unused variable member initial_coords in class Boomerang.

### DIFF
--- a/include/entities/Boomerang.h
+++ b/include/entities/Boomerang.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -85,7 +85,6 @@ class Boomerang: public MapEntity {
     bool has_to_go_back;            /**< true if the boomerang is about to go back */
     bool going_back;                /**< indicates that the boomerang is going back towards the hero */
 
-    Rectangle initial_coords;       /**< coordinates of the boomerang's initial position */
     int speed;                      /**< speed of the movement in pixels per second */
 
 };

--- a/src/entities/Boomerang.cpp
+++ b/src/entities/Boomerang.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -78,8 +78,6 @@ Boomerang::Boomerang(
       break;
 
   }
-
-  initial_coords.set_xy(get_xy());
 
   StraightMovement* movement = new StraightMovement(false, false);
   movement->set_speed(speed);


### PR DESCRIPTION
initial_coords in Boomerang was set but never used anywhere else. Neither were there any TODO to use it later.
