### PR TITLE
Removed useless includes of standard headers vector, list, set and map.

### DIFF
--- a/include/EquipmentItem.h
+++ b/include/EquipmentItem.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,6 @@
 #include "lua/ExportableToLua.h"
 #include "Ability.h"
 #include <string>
-#include <vector>
 
 namespace solarus {
 

--- a/include/MainLoop.h
+++ b/include/MainLoop.h
@@ -19,7 +19,6 @@
 
 #include "Common.h"
 #include <string>
-#include <vector>
 
 namespace solarus {
 

--- a/include/QuestResourceList.h
+++ b/include/QuestResourceList.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,7 +20,6 @@
 
 #include "Common.h"
 #include <vector>
-#include <map>
 #include <string>
 
 namespace solarus {

--- a/include/StringResource.h
+++ b/include/StringResource.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,7 +19,6 @@
 
 #include "Common.h"
 #include <string>
-#include <map>
 
 namespace solarus {
 

--- a/include/entities/Fire.h
+++ b/include/entities/Fire.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,7 +19,6 @@
 
 #include "Common.h"
 #include "entities/Detector.h"
-#include <list>
 
 namespace solarus {
 

--- a/include/entities/NonAnimatedRegions.h
+++ b/include/entities/NonAnimatedRegions.h
@@ -21,7 +21,6 @@
 #include "entities/Layer.h"
 #include "containers/Grid.h"
 #include <vector>
-#include <set>
 
 namespace solarus {
 

--- a/include/entities/Separator.h
+++ b/include/entities/Separator.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2012 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,7 +19,6 @@
 
 #include "Common.h"
 #include "entities/Detector.h"
-#include <list>
 
 namespace solarus {
 

--- a/include/lowlevel/Video.h
+++ b/include/lowlevel/Video.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,7 +20,6 @@
 #include "Common.h"
 #include "lowlevel/Rectangle.h"
 #include <vector>
-#include <map>
 #include <string>
 
 struct SDL_PixelFormat;

--- a/src/QuestResourceList.cpp
+++ b/src/QuestResourceList.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #include "lowlevel/FileTools.h"
 #include "lowlevel/Debug.h"
 #include "lua/LuaTools.h"
+#include <map>
 #include <sstream>
 
 namespace solarus {

--- a/src/StringResource.cpp
+++ b/src/StringResource.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #include "Language.h"
 #include "lowlevel/FileTools.h"
 #include "lua/LuaTools.h"
+#include <map>
 #include <sstream>
 
 namespace solarus {

--- a/src/entities/CrystalBlock.cpp
+++ b/src/entities/CrystalBlock.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,7 +23,6 @@
 #include "Sprite.h"
 #include "lowlevel/FileTools.h"
 #include "lowlevel/Sound.h"
-#include <list>
 
 namespace solarus {
 

--- a/src/lowlevel/Video.cpp
+++ b/src/lowlevel/Video.cpp
@@ -26,7 +26,6 @@
 #include "lowlevel/Debug.h"
 #include "lowlevel/shaders/ShaderContext.h"
 #include "CommandLine.h"
-#include <map>
 #include <algorithm>
 #include <sstream>
 #include <iostream>
@@ -265,7 +264,7 @@ void Video::initialize(const CommandLine& args) {
 void Video::quit() {
 
   ShaderContext::quit();
-  
+
   if (is_fullscreen()) {
     // Get back on desktop before destroy the window.
     SDL_SetWindowFullscreen(main_window, 0);
@@ -302,7 +301,7 @@ SDL_Window* Video::get_window() {
 SDL_Renderer* Video::get_renderer() {
   return main_renderer;
 }
-  
+
 /**
  * \brief Returns the render texture target, if any.
  * \return the render target, or NULL.
@@ -439,7 +438,7 @@ void Video::switch_video_mode() {
 
   set_video_mode(*mode);
 }
-  
+
 /**
  * \brief Sets the video mode, keeping the fullscreen setting unchanged.
  * \param mode The video mode to set.
@@ -482,7 +481,7 @@ bool Video::set_video_mode(const VideoMode& mode, bool fullscreen) {
 
   video_mode = &mode;
   fullscreen_window = fullscreen;
-  
+
   if (!disable_window) {
 
     RefCountable::unref(scaled_surface);
@@ -519,7 +518,7 @@ bool Video::set_video_mode(const VideoMode& mode, bool fullscreen) {
         render_size.get_width(),
         render_size.get_height());
     SDL_ShowCursor(show_cursor);
-    
+
     if (mode_changed) {
       reset_window_size();
     }
@@ -568,7 +567,7 @@ const VideoMode* Video::get_video_mode_by_name(
       return all_video_modes[i];
     }
   }
-  
+
   return NULL;
 }
 


### PR DESCRIPTION
I cleaned a little bit the includes of standard headers. I removed the unused includes of <vector>, <list>, <set> and <map>. When possible, I also moved the include from the .h to the .cpp.
