### PR TITLE
Replaced &vec[0] syntax by vec.data().

### DIFF
--- a/src/lowlevel/Sound.cpp
+++ b/src/lowlevel/Sound.cpp
@@ -423,7 +423,7 @@ ALuint Sound::decode_file(const std::string& file_name) {
       }
       alBufferData(buffer,
           AL_FORMAT_STEREO16,
-          reinterpret_cast<ALshort*>(&samples[0]),
+          reinterpret_cast<ALshort*>(samples.data()),
           ALsizei(total_bytes_read),
           sample_rate);
       ALenum error = alGetError();


### PR DESCRIPTION
I missed one occurence of &vec[0] in the previous commit. This one replaces it by vec.data().
