### PR TITLE
Removed to unused variable declarations.

### DIFF
--- a/src/entities/DynamicTile.cpp
+++ b/src/entities/DynamicTile.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -98,7 +98,6 @@ void DynamicTile::draw_on_map() {
   }
 
   const Rectangle& camera_position = get_map().get_camera_position();
-  Rectangle dst(0, 0);
 
   Rectangle dst_position(get_top_left_x() - camera_position.get_x(),
       get_top_left_y() - camera_position.get_y(),

--- a/src/entities/NonAnimatedRegions.cpp
+++ b/src/entities/NonAnimatedRegions.cpp
@@ -99,7 +99,6 @@ void NonAnimatedRegions::build(std::vector<Tile*>& rejected_tiles) {
   Debug::check_assertion(optimized_tiles_surfaces.empty(),
       "Tile regions are already built");
 
-  const Rectangle map_size(0, 0, map.get_width(), map.get_height());
   const int map_width8 = map.get_width8();
   const int map_height8 = map.get_height8();
 


### PR DESCRIPTION
It seems that the compiler does not detect variables that are unused but have been initialized, probably because the initialization may have side effects. Removed two variables unused after having been declared.
