### PR TITLE
Changed the macro-based exception boundary by a lambda-based one.

### DIFF
--- a/include/lua/LuaTools.h
+++ b/include/lua/LuaTools.h
@@ -25,36 +25,6 @@
 #include <vector>
 #include <lua.hpp>
 
-/**
- * \brief Try block to be used at the Lua to C++ boundary.
- *
- * The whole code of any function that can directly be called from Lua must be
- * protected by a SOLARUS_LUA_API_TRY() block, including the declaration of
- * variables and the return instructions.
- */
-#define SOLARUS_LUA_BOUNDARY_TRY() try
-
-/**
- * \brief Catch block to be used at the Lua to C++ boundary.
- *
- * This macro is meant to be called at the end of in any C++ function that
- * can directly be called be Lua, after the SOLARUS_LUA_API_TRY() block.
- * Any exception is caught and generates a Lua error instead.
- *
- * \param l The Lua state.
- */
-#define SOLARUS_LUA_BOUNDARY_CATCH(l)\
-    catch (const LuaException& ex) {\
-      luaL_error(l, ex.what());\
-    }\
-    catch (const std::exception& ex) {\
-      luaL_error(l, (std::string("Unexpected exception: ") + ex.what()).c_str());\
-    }\
-    catch (...) {\
-      luaL_error(l, "Unexpected exception");\
-    }\
-    return 0;
-
 namespace solarus {
 
 class Color;
@@ -107,6 +77,12 @@ class LuaTools {
     static void check_any(
         lua_State* l,
         int arg_index
+    );
+
+    template<typename Callable>
+    static int exception_boundary_handle(
+        lua_State* l,
+        Callable&& func
     );
 
     // int
@@ -304,6 +280,38 @@ class LuaTools {
     LuaTools() = delete;  // Don't instantiate this class.
 
 };
+
+/**
+ * \brief Function to be used at the Lua to C++ boundary.
+ *
+ * The whole code of any function that can directly be called from Lua must be
+ * wrapped in a lambda passed to exception_boundary_handle, including the
+ * declaration of variables and the return instructions.
+ * Any exception is caught and generates a Lua error instead.
+ *
+ * \param l The Lua state.
+ * \param func The lambda wrapping the code.
+ */
+template<typename Callable>
+int LuaTools::exception_boundary_handle(
+    lua_State* l,
+    Callable&& func
+) {
+  try
+  {
+    return func();
+  }
+  catch (const LuaException& ex) {
+    luaL_error(l, ex.what());
+  }
+  catch (const std::exception& ex) {
+    luaL_error(l, (std::string("Unexpected exception: ") + ex.what()).c_str());
+  }
+  catch (...) {
+    luaL_error(l, "Unexpected exception");
+  }
+  return 0;
+}
 
 /**
  * \brief Checks whether a value is the name of an enumeration value and

--- a/src/DialogResource.cpp
+++ b/src/DialogResource.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -117,7 +117,7 @@ const Dialog& DialogResource::get_dialog(const std::string& dialog_id) {
  */
 int DialogResource::l_dialog(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaTools::check_type(l, 1, LUA_TTABLE);
 
     const std::string dialog_id = LuaTools::check_string_field(l, 1, "id");
@@ -168,8 +168,7 @@ int DialogResource::l_dialog(lua_State* l) {
     dialogs[dialog_id] = dialog;
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/MapLoader.cpp
+++ b/src/MapLoader.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -99,7 +99,7 @@ void MapLoader::load_map(Game& game, Map& map) {
  */
 int MapLoader::l_properties(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     // Retrieve the map to build.
     Map* map = LuaContext::get_entity_implicit_creation_map(l);
     Debug::check_assertion(map != nullptr, "No map has not been set in this Lua state");
@@ -179,8 +179,7 @@ int MapLoader::l_properties(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/QuestProperties.cpp
+++ b/src/QuestProperties.cpp
@@ -128,7 +128,7 @@ void QuestProperties::load() {
 
 int QuestProperties::l_quest(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     // Retrieve the quest properties from the table parameter.
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& solarus_required_version =
@@ -185,8 +185,7 @@ int QuestProperties::l_quest(lua_State* l) {
         max_quest_size);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/QuestResourceList.cpp
+++ b/src/QuestResourceList.cpp
@@ -49,7 +49,7 @@ namespace {
    */
   int l_resource_element(lua_State* l) {
 
-    SOLARUS_LUA_BOUNDARY_TRY() {
+    return LuaTools::exception_boundary_handle(l, [&] {
       QuestResourceList::ResourceType resource_type =
           LuaTools::check_enum<QuestResourceList::ResourceType>(l, 1, resource_type_names);
       const std::string& id = LuaTools::check_string_field(l, 2, "id");
@@ -59,8 +59,7 @@ namespace {
       resource_map[resource_type][id] = description;
 
       return 0;
-    }
-    SOLARUS_LUA_BOUNDARY_CATCH(l);
+    });
   }
 
 }

--- a/src/Savegame.cpp
+++ b/src/Savegame.cpp
@@ -234,7 +234,7 @@ void Savegame::load() {
  */
 int Savegame::l_newindex(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     lua_getfield(l, LUA_REGISTRYINDEX, "savegame");
     Savegame* savegame = static_cast<Savegame*>(lua_touserdata(l, -1));
     lua_pop(l, 1);
@@ -260,8 +260,7 @@ int Savegame::l_newindex(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/SpriteAnimationSet.cpp
+++ b/src/SpriteAnimationSet.cpp
@@ -92,7 +92,7 @@ void SpriteAnimationSet::load() {
  */
 int SpriteAnimationSet::l_animation(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     lua_getfield(l, LUA_REGISTRYINDEX, "animation_set");
     SpriteAnimationSet* animation_set = static_cast<SpriteAnimationSet*>(
         lua_touserdata(l, -1));
@@ -200,8 +200,7 @@ int SpriteAnimationSet::l_animation(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/StringResource.cpp
+++ b/src/StringResource.cpp
@@ -36,7 +36,7 @@ std::map<std::string, std::string> strings;
  */
 int l_text(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaTools::check_type(l, 1, LUA_TTABLE);
 
     const std::string key = LuaTools::check_string_field(l, 1, "key");
@@ -45,8 +45,7 @@ int l_text(lua_State* l) {
     strings[key] = value;
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/entities/Tileset.cpp
+++ b/src/entities/Tileset.cpp
@@ -223,7 +223,7 @@ void Tileset::set_images(const std::string& other_id) {
  */
 int Tileset::l_background_color(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     lua_getfield(l, LUA_REGISTRYINDEX, "tileset");
     Tileset* tileset = static_cast<Tileset*>(lua_touserdata(l, -1));
     lua_pop(l, 1);
@@ -242,8 +242,7 @@ int Tileset::l_background_color(lua_State* l) {
     tileset->background_color = color;
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -256,7 +255,7 @@ int Tileset::l_background_color(lua_State* l) {
  */
 int Tileset::l_tile_pattern(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     lua_getfield(l, LUA_REGISTRYINDEX, "tileset");
     Tileset* tileset = static_cast<Tileset*>(lua_touserdata(l, -1));
     lua_pop(l, 1);
@@ -348,8 +347,7 @@ int Tileset::l_tile_pattern(lua_State* l) {
     tileset->add_tile_pattern(id, tile_pattern);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lowlevel/TextSurface.cpp
+++ b/src/lowlevel/TextSurface.cpp
@@ -114,7 +114,7 @@ void TextSurface::quit() {
  */
 int TextSurface::l_font(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaTools::check_type(l, 1, LUA_TTABLE);
 
     const std::string& font_id = LuaTools::check_string_field(l, 1, "id");
@@ -154,8 +154,7 @@ int TextSurface::l_font(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lowlevel/shaders/GL_ARBShader.cpp
+++ b/src/lowlevel/shaders/GL_ARBShader.cpp
@@ -185,7 +185,7 @@ void GL_ARBShader::set_rendering_settings() {
  */
 int GL_ARBShader::l_shader(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     if (loading_shader != nullptr) {
 
       GLhandleARB& program = loading_shader->program,
@@ -239,8 +239,7 @@ int GL_ARBShader::l_shader(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/AudioApi.cpp
+++ b/src/lua/AudioApi.cpp
@@ -61,11 +61,10 @@ void LuaContext::register_audio_module() {
  */
 int LuaContext::audio_api_get_sound_volume(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     lua_pushinteger(l, Sound::get_volume());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -75,13 +74,12 @@ int LuaContext::audio_api_get_sound_volume(lua_State* l) {
  */
 int LuaContext::audio_api_set_sound_volume(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int volume = LuaTools::check_int(l, 1);
     Sound::set_volume(volume);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -91,7 +89,7 @@ int LuaContext::audio_api_set_sound_volume(lua_State* l) {
  */
 int LuaContext::audio_api_play_sound(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& sound_id = LuaTools::check_string(l, 1);
 
     if (!Sound::exists(sound_id)) {
@@ -100,8 +98,7 @@ int LuaContext::audio_api_play_sound(lua_State* l) {
     Sound::play(sound_id);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -111,11 +108,10 @@ int LuaContext::audio_api_play_sound(lua_State* l) {
  */
 int LuaContext::audio_api_preload_sounds(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Sound::load_all();
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -125,11 +121,10 @@ int LuaContext::audio_api_preload_sounds(lua_State* l) {
  */
 int LuaContext::audio_api_get_music_volume(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     lua_pushinteger(l, Music::get_volume());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -139,14 +134,13 @@ int LuaContext::audio_api_get_music_volume(lua_State* l) {
  */
 int LuaContext::audio_api_set_music_volume(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int volume = LuaTools::check_int(l, 1);
 
     Music::set_volume(volume);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -156,7 +150,7 @@ int LuaContext::audio_api_set_music_volume(lua_State* l) {
  */
 int LuaContext::audio_api_play_music(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& music_id = LuaTools::opt_string(l, 1, "");
     bool loop = true;  // true by default, unless there is a callback.
     ScopedLuaRef callback_ref;
@@ -186,8 +180,7 @@ int LuaContext::audio_api_play_music(lua_State* l) {
       Music::play(music_id, loop, callback_ref);
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -197,12 +190,11 @@ int LuaContext::audio_api_play_music(lua_State* l) {
  */
 int LuaContext::audio_api_stop_music(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Music::stop_playing();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -212,7 +204,7 @@ int LuaContext::audio_api_stop_music(lua_State* l) {
  */
 int LuaContext::audio_api_get_music(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& music_id = Music::get_current_music_id();
 
     if (music_id == Music::none) {
@@ -222,8 +214,7 @@ int LuaContext::audio_api_get_music(lua_State* l) {
       push_string(l, music_id);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -233,7 +224,7 @@ int LuaContext::audio_api_get_music(lua_State* l) {
  */
 int LuaContext::audio_api_get_music_format(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Music::Format format = Music::get_format();
 
     if (format == Music::NO_FORMAT) {
@@ -244,8 +235,7 @@ int LuaContext::audio_api_get_music_format(lua_State* l) {
       push_string(l, Music::format_names[format]);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -255,7 +245,7 @@ int LuaContext::audio_api_get_music_format(lua_State* l) {
  */
 int LuaContext::audio_api_get_music_num_channels(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     if (Music::get_format() != Music::IT) {
       lua_pushnil(l);
     }
@@ -263,8 +253,7 @@ int LuaContext::audio_api_get_music_num_channels(lua_State* l) {
       lua_pushinteger(l, Music::get_num_channels());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -274,7 +263,7 @@ int LuaContext::audio_api_get_music_num_channels(lua_State* l) {
  */
 int LuaContext::audio_api_get_music_channel_volume(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int channel = LuaTools::check_int(l, 1);
 
     if (Music::get_format() != Music::IT) {
@@ -289,8 +278,7 @@ int LuaContext::audio_api_get_music_channel_volume(lua_State* l) {
       lua_pushinteger(l, Music::get_channel_volume(channel));
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -300,7 +288,7 @@ int LuaContext::audio_api_get_music_channel_volume(lua_State* l) {
  */
 int LuaContext::audio_api_set_music_channel_volume(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int channel = LuaTools::check_int(l, 1);
     int volume = LuaTools::check_int(l, 2);
 
@@ -317,8 +305,7 @@ int LuaContext::audio_api_set_music_channel_volume(lua_State* l) {
       lua_pushboolean(l, true);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -328,7 +315,7 @@ int LuaContext::audio_api_set_music_channel_volume(lua_State* l) {
  */
 int LuaContext::audio_api_get_music_tempo(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     if (Music::get_format() != Music::IT) {
       lua_pushnil(l);
     }
@@ -336,8 +323,7 @@ int LuaContext::audio_api_get_music_tempo(lua_State* l) {
       lua_pushinteger(l, Music::get_tempo());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -347,7 +333,7 @@ int LuaContext::audio_api_get_music_tempo(lua_State* l) {
  */
 int LuaContext::audio_api_set_music_tempo(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int tempo = LuaTools::check_int(l, 1);
 
     if (Music::get_format() != Music::IT) {
@@ -358,8 +344,7 @@ int LuaContext::audio_api_set_music_tempo(lua_State* l) {
       lua_pushboolean(l, true);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lua/DrawableApi.cpp
+++ b/src/lua/DrawableApi.cpp
@@ -129,7 +129,7 @@ void LuaContext::update_drawables() {
  */
 int LuaContext::drawable_api_draw(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Drawable> drawable = check_drawable(l, 1);
     SurfacePtr dst_surface = check_surface(l, 2);
     int x = LuaTools::opt_int(l, 3, 0);
@@ -137,8 +137,7 @@ int LuaContext::drawable_api_draw(lua_State* l) {
     drawable->draw(dst_surface, x, y);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -148,7 +147,7 @@ int LuaContext::drawable_api_draw(lua_State* l) {
  */
 int LuaContext::drawable_api_draw_region(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Drawable> drawable = check_drawable(l, 1);
     Rectangle region = {
         LuaTools::check_int(l, 2),
@@ -164,8 +163,7 @@ int LuaContext::drawable_api_draw_region(lua_State* l) {
     drawable->draw_region(region, dst_surface, dst_position);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -175,7 +173,7 @@ int LuaContext::drawable_api_draw_region(lua_State* l) {
  */
 int LuaContext::drawable_api_fade_in(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     uint32_t delay = 20;
     ScopedLuaRef callback_ref;
 
@@ -201,8 +199,7 @@ int LuaContext::drawable_api_fade_in(lua_State* l) {
     drawable->start_transition(*transition, callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -212,7 +209,7 @@ int LuaContext::drawable_api_fade_in(lua_State* l) {
  */
 int LuaContext::drawable_api_fade_out(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     uint32_t delay = 20;
     ScopedLuaRef callback_ref;
 
@@ -237,8 +234,7 @@ int LuaContext::drawable_api_fade_out(lua_State* l) {
     drawable->start_transition(*transition, callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -248,14 +244,13 @@ int LuaContext::drawable_api_fade_out(lua_State* l) {
  */
 int LuaContext::drawable_api_get_xy(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Drawable> drawable = check_drawable(l, 1);
 
     lua_pushinteger(l, drawable->get_xy().x);
     lua_pushinteger(l, drawable->get_xy().y);
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -265,7 +260,7 @@ int LuaContext::drawable_api_get_xy(lua_State* l) {
  */
 int LuaContext::drawable_api_set_xy(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Drawable> drawable = check_drawable(l, 1);
     int x = LuaTools::check_int(l, 2);
     int y = LuaTools::check_int(l, 3);
@@ -273,8 +268,7 @@ int LuaContext::drawable_api_set_xy(lua_State* l) {
     drawable->set_xy(Point(x, y));
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -284,7 +278,7 @@ int LuaContext::drawable_api_set_xy(lua_State* l) {
  */
 int LuaContext::drawable_api_get_movement(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Drawable> drawable = check_drawable(l, 1);
     std::shared_ptr<Movement> movement = drawable->get_movement();
     if (movement == nullptr) {
@@ -295,8 +289,7 @@ int LuaContext::drawable_api_get_movement(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -306,14 +299,13 @@ int LuaContext::drawable_api_get_movement(lua_State* l) {
  */
 int LuaContext::drawable_api_stop_movement(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Drawable> drawable = check_drawable(l, 1);
 
     drawable->stop_movement();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -323,7 +315,7 @@ int LuaContext::drawable_api_stop_movement(lua_State* l) {
  */
 int LuaContext::drawable_meta_gc(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
     std::shared_ptr<Drawable> drawable = check_drawable(l, 1);
 
@@ -332,10 +324,9 @@ int LuaContext::drawable_meta_gc(lua_State* l) {
       lua_context.remove_drawable(drawable);
     }
     userdata_meta_gc(l);
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
 
-  return 0;
+    return 0;
+  });
 }
 
 }

--- a/src/lua/EntityApi.cpp
+++ b/src/lua/EntityApi.cpp
@@ -611,13 +611,12 @@ const std::string& LuaContext::get_entity_internal_type_name(
  */
 int LuaContext::entity_api_get_type(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     push_string(l, entity_type_names[entity.get_type()]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -627,13 +626,12 @@ int LuaContext::entity_api_get_type(lua_State* l) {
  */
 int LuaContext::entity_api_get_map(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     push_map(l, entity.get_map());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -643,13 +641,12 @@ int LuaContext::entity_api_get_map(lua_State* l) {
  */
 int LuaContext::entity_api_get_game(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     push_game(l, entity.get_game().get_savegame());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -659,7 +656,7 @@ int LuaContext::entity_api_get_game(lua_State* l) {
  */
 int LuaContext::entity_api_get_name(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     const std::string& name = entity.get_name();
@@ -670,8 +667,7 @@ int LuaContext::entity_api_get_name(lua_State* l) {
       push_string(l, name);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -681,13 +677,12 @@ int LuaContext::entity_api_get_name(lua_State* l) {
  */
 int LuaContext::entity_api_exists(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     lua_pushboolean(l, !entity.is_being_removed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -697,14 +692,13 @@ int LuaContext::entity_api_exists(lua_State* l) {
  */
 int LuaContext::entity_api_remove(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     entity.remove_from_map();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -714,13 +708,12 @@ int LuaContext::entity_api_remove(lua_State* l) {
  */
 int LuaContext::entity_api_is_enabled(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     lua_pushboolean(l, entity.is_enabled());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -730,7 +723,7 @@ int LuaContext::entity_api_is_enabled(lua_State* l) {
  */
 int LuaContext::entity_api_set_enabled(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     bool enabled = true;
     if (lua_gettop(l) >= 2) {
@@ -740,8 +733,7 @@ int LuaContext::entity_api_set_enabled(lua_State* l) {
     entity.set_enabled(enabled);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -751,14 +743,13 @@ int LuaContext::entity_api_set_enabled(lua_State* l) {
  */
 int LuaContext::entity_api_get_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     lua_pushinteger(l, entity.get_width());
     lua_pushinteger(l, entity.get_height());
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -768,7 +759,7 @@ int LuaContext::entity_api_get_size(lua_State* l) {
  */
 int LuaContext::entity_api_set_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     int width = LuaTools::check_int(l, 2);
     int height = LuaTools::check_int(l, 3);
@@ -787,8 +778,7 @@ int LuaContext::entity_api_set_size(lua_State* l) {
     entity.set_size(width, height);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -798,7 +788,7 @@ int LuaContext::entity_api_set_size(lua_State* l) {
  */
 int LuaContext::entity_api_get_origin(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     const Point& origin = entity.get_origin();
@@ -806,8 +796,7 @@ int LuaContext::entity_api_get_origin(lua_State* l) {
     lua_pushinteger(l, origin.x);
     lua_pushinteger(l, origin.y);
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -817,7 +806,7 @@ int LuaContext::entity_api_get_origin(lua_State* l) {
  */
 int LuaContext::entity_api_set_origin(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     int x = LuaTools::check_int(l, 2);
     int y = LuaTools::check_int(l, 3);
@@ -825,8 +814,7 @@ int LuaContext::entity_api_set_origin(lua_State* l) {
     entity.set_origin(x, y);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -836,15 +824,14 @@ int LuaContext::entity_api_set_origin(lua_State* l) {
  */
 int LuaContext::entity_api_get_position(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     lua_pushinteger(l, entity.get_x());
     lua_pushinteger(l, entity.get_y());
     lua_pushinteger(l, entity.get_layer());
     return 3;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -854,7 +841,7 @@ int LuaContext::entity_api_get_position(lua_State* l) {
  */
 int LuaContext::entity_api_set_position(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     int x = LuaTools::check_int(l, 2);
     int y = LuaTools::check_int(l, 3);
@@ -871,8 +858,7 @@ int LuaContext::entity_api_set_position(lua_State* l) {
     entity.notify_position_changed();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -882,15 +868,14 @@ int LuaContext::entity_api_set_position(lua_State* l) {
  */
 int LuaContext::entity_api_get_center_position(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     const Rectangle& center_point = entity.get_center_point();
     lua_pushinteger(l, center_point.get_x());
     lua_pushinteger(l, center_point.get_y());
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -900,7 +885,7 @@ int LuaContext::entity_api_get_center_position(lua_State* l) {
  */
 int LuaContext::entity_api_get_bounding_box(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     const Rectangle& bounding_box = entity.get_bounding_box();
@@ -909,8 +894,7 @@ int LuaContext::entity_api_get_bounding_box(lua_State* l) {
     lua_pushinteger(l, bounding_box.get_width());
     lua_pushinteger(l, bounding_box.get_height());
     return 4;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -920,7 +904,7 @@ int LuaContext::entity_api_get_bounding_box(lua_State* l) {
  */
 int LuaContext::entity_api_overlaps(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     bool overlaps = false;
@@ -938,8 +922,7 @@ int LuaContext::entity_api_overlaps(lua_State* l) {
 
     lua_pushboolean(l, overlaps);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -949,14 +932,13 @@ int LuaContext::entity_api_overlaps(lua_State* l) {
  */
 int LuaContext::entity_api_snap_to_grid(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     entity.set_aligned_to_grid();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -966,7 +948,7 @@ int LuaContext::entity_api_snap_to_grid(lua_State* l) {
  */
 int LuaContext::entity_api_get_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     int distance;
     if (lua_gettop(l) >= 3) {
@@ -981,8 +963,7 @@ int LuaContext::entity_api_get_distance(lua_State* l) {
 
     lua_pushinteger(l, distance);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -992,7 +973,7 @@ int LuaContext::entity_api_get_distance(lua_State* l) {
  */
 int LuaContext::entity_api_get_angle(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     double angle;
     if (lua_gettop(l) >= 3) {
@@ -1007,8 +988,7 @@ int LuaContext::entity_api_get_angle(lua_State* l) {
 
     lua_pushnumber(l, angle);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1018,7 +998,7 @@ int LuaContext::entity_api_get_angle(lua_State* l) {
  */
 int LuaContext::entity_api_get_direction4_to(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     double angle;
     if (lua_gettop(l) >= 3) {
@@ -1039,8 +1019,7 @@ int LuaContext::entity_api_get_direction4_to(lua_State* l) {
 
     lua_pushnumber(l, direction4);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1050,7 +1029,7 @@ int LuaContext::entity_api_get_direction4_to(lua_State* l) {
  */
 int LuaContext::entity_api_get_direction8_to(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     double angle;
     if (lua_gettop(l) >= 3) {
@@ -1071,8 +1050,7 @@ int LuaContext::entity_api_get_direction8_to(lua_State* l) {
 
     lua_pushnumber(l, direction8);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1082,14 +1060,13 @@ int LuaContext::entity_api_get_direction8_to(lua_State* l) {
  */
 int LuaContext::entity_api_bring_to_front(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     entity.get_map().get_entities().bring_to_front(entity);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1099,14 +1076,13 @@ int LuaContext::entity_api_bring_to_front(lua_State* l) {
  */
 int LuaContext::entity_api_bring_to_back(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     entity.get_map().get_entities().bring_to_back(entity);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1117,7 +1093,7 @@ int LuaContext::entity_api_bring_to_back(lua_State* l) {
  */
 int LuaContext::entity_api_get_sprite(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     if (entity.has_sprite()) {
@@ -1127,8 +1103,7 @@ int LuaContext::entity_api_get_sprite(lua_State* l) {
       lua_pushnil(l);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1138,7 +1113,7 @@ int LuaContext::entity_api_get_sprite(lua_State* l) {
  */
 int LuaContext::entity_api_create_sprite(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     const std::string& animation_set_id = LuaTools::check_string(l, 2);
 
@@ -1149,8 +1124,7 @@ int LuaContext::entity_api_create_sprite(lua_State* l) {
 
     push_sprite(l, sprite);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1160,7 +1134,7 @@ int LuaContext::entity_api_create_sprite(lua_State* l) {
  */
 int LuaContext::entity_api_remove_sprite(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     if (lua_gettop(l) >= 2) {
@@ -1173,8 +1147,7 @@ int LuaContext::entity_api_remove_sprite(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1184,13 +1157,12 @@ int LuaContext::entity_api_remove_sprite(lua_State* l) {
  */
 int LuaContext::entity_api_is_visible(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     lua_pushboolean(l, entity.is_visible());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1200,7 +1172,7 @@ int LuaContext::entity_api_is_visible(lua_State* l) {
  */
 int LuaContext::entity_api_set_visible(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     bool visible = true;
     if (lua_gettop(l) >= 2) {
@@ -1210,8 +1182,7 @@ int LuaContext::entity_api_set_visible(lua_State* l) {
     entity.set_visible(visible);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1221,7 +1192,7 @@ int LuaContext::entity_api_set_visible(lua_State* l) {
  */
 int LuaContext::entity_api_get_movement(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     const std::shared_ptr<Movement>& movement = entity.get_movement();
@@ -1233,8 +1204,7 @@ int LuaContext::entity_api_get_movement(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1260,7 +1230,7 @@ int LuaContext::entity_api_stop_movement(lua_State* l) {
  */
 int LuaContext::entity_api_has_layer_independent_collisions(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     bool independent = false;
@@ -1271,8 +1241,7 @@ int LuaContext::entity_api_has_layer_independent_collisions(lua_State* l) {
 
     lua_pushboolean(l, independent);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1284,7 +1253,7 @@ int LuaContext::entity_api_has_layer_independent_collisions(lua_State* l) {
  */
 int LuaContext::entity_api_set_layer_independent_collisions(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     bool independent = true;
     if (lua_gettop(l) >= 2) {
@@ -1297,8 +1266,7 @@ int LuaContext::entity_api_set_layer_independent_collisions(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1308,7 +1276,7 @@ int LuaContext::entity_api_set_layer_independent_collisions(lua_State* l) {
  */
 int LuaContext::entity_api_test_obstacles(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     int dx = LuaTools::check_int(l, 2);
     int dy = LuaTools::check_int(l, 3);
@@ -1323,8 +1291,7 @@ int LuaContext::entity_api_test_obstacles(lua_State* l) {
     lua_pushboolean(l, entity.get_map().test_collision_with_obstacles(
         layer, bounding_box, entity));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1334,13 +1301,12 @@ int LuaContext::entity_api_test_obstacles(lua_State* l) {
  */
 int LuaContext::entity_api_get_optimization_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
 
     lua_pushinteger(l, entity.get_optimization_distance());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1350,15 +1316,14 @@ int LuaContext::entity_api_get_optimization_distance(lua_State* l) {
  */
 int LuaContext::entity_api_set_optimization_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     int distance = LuaTools::check_int(l, 2);
 
     entity.set_optimization_distance(distance);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1368,14 +1333,13 @@ int LuaContext::entity_api_set_optimization_distance(lua_State* l) {
  */
 int LuaContext::entity_api_is_in_same_region(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     MapEntity& entity = *check_entity(l, 1);
     MapEntity& other_entity = *check_entity(l, 2);
 
     lua_pushboolean(l, entity.is_in_same_region(other_entity));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1417,7 +1381,7 @@ void LuaContext::push_hero(lua_State* l, Hero& hero) {
  */
 int LuaContext::hero_api_teleport(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     const std::string& map_id = LuaTools::check_string(l, 2);
     const std::string& destination_name = LuaTools::opt_string(l, 3, "");
@@ -1431,8 +1395,7 @@ int LuaContext::hero_api_teleport(lua_State* l) {
     hero.get_game().set_current_map(map_id, destination_name, transition_style);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1442,13 +1405,12 @@ int LuaContext::hero_api_teleport(lua_State* l) {
  */
 int LuaContext::hero_api_get_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     lua_pushinteger(l, hero.get_animation_direction());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1458,15 +1420,14 @@ int LuaContext::hero_api_get_direction(lua_State* l) {
  */
 int LuaContext::hero_api_set_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     int direction = LuaTools::check_int(l, 2);
 
     hero.set_animation_direction(direction);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1476,13 +1437,12 @@ int LuaContext::hero_api_set_direction(lua_State* l) {
  */
 int LuaContext::hero_api_get_walking_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     lua_pushinteger(l, hero.get_normal_walking_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1492,15 +1452,14 @@ int LuaContext::hero_api_get_walking_speed(lua_State* l) {
  */
 int LuaContext::hero_api_set_walking_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     int normal_walking_speed = LuaTools::check_int(l, 2);
 
     hero.set_normal_walking_speed(normal_walking_speed);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1510,7 +1469,7 @@ int LuaContext::hero_api_set_walking_speed(lua_State* l) {
  */
 int LuaContext::hero_api_save_solid_ground(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     int x, y;
     Layer layer;
@@ -1528,8 +1487,7 @@ int LuaContext::hero_api_save_solid_ground(lua_State* l) {
     hero.set_target_solid_ground_coords(Point(x, y), layer);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1539,14 +1497,13 @@ int LuaContext::hero_api_save_solid_ground(lua_State* l) {
  */
 int LuaContext::hero_api_reset_solid_ground(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     hero.reset_target_solid_ground_coords();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1556,7 +1513,7 @@ int LuaContext::hero_api_reset_solid_ground(lua_State* l) {
  */
 int LuaContext::hero_api_get_solid_ground_position(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Hero& hero = check_hero(l, 1);
 
     const Point& target_coords = hero.get_target_solid_ground_coords();
@@ -1581,8 +1538,7 @@ int LuaContext::hero_api_get_solid_ground_position(lua_State* l) {
     // Maybe the map started in water.
     lua_pushnil(l);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1592,15 +1548,14 @@ int LuaContext::hero_api_get_solid_ground_position(lua_State* l) {
  */
 int LuaContext::hero_api_get_animation(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     const std::string& animation = hero.get_hero_sprites().get_tunic_animation();
 
     push_string(l, animation);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1610,7 +1565,7 @@ int LuaContext::hero_api_get_animation(lua_State* l) {
  */
 int LuaContext::hero_api_set_animation(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     const std::string& animation = LuaTools::check_string(l, 2);
     const ScopedLuaRef& callback_ref = LuaTools::opt_function(l, 3);
@@ -1625,8 +1580,7 @@ int LuaContext::hero_api_set_animation(lua_State* l) {
     sprites.set_animation(animation, callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1636,15 +1590,14 @@ int LuaContext::hero_api_set_animation(lua_State* l) {
  */
 int LuaContext::hero_api_get_tunic_sprite_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     const std::string& sprite_id = hero.get_hero_sprites().get_tunic_sprite_id();
 
     push_string(l, sprite_id);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1654,7 +1607,7 @@ int LuaContext::hero_api_get_tunic_sprite_id(lua_State* l) {
  */
 int LuaContext::hero_api_set_tunic_sprite_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     const std::string& sprite_id = LuaTools::check_string(l, 2);
 
@@ -1663,8 +1616,7 @@ int LuaContext::hero_api_set_tunic_sprite_id(lua_State* l) {
     hero.get_hero_sprites().set_tunic_sprite_id(sprite_id);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1674,15 +1626,14 @@ int LuaContext::hero_api_set_tunic_sprite_id(lua_State* l) {
  */
 int LuaContext::hero_api_get_sword_sprite_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     const std::string& sprite_id = hero.get_hero_sprites().get_sword_sprite_id();
 
     push_string(l, sprite_id);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1692,15 +1643,14 @@ int LuaContext::hero_api_get_sword_sprite_id(lua_State* l) {
  */
 int LuaContext::hero_api_set_sword_sprite_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     const std::string& sprite_id = LuaTools::check_string(l, 2);
 
     hero.get_hero_sprites().set_sword_sprite_id(sprite_id);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1710,15 +1660,14 @@ int LuaContext::hero_api_set_sword_sprite_id(lua_State* l) {
  */
 int LuaContext::hero_api_get_sword_sound_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     const std::string& sound_id = hero.get_hero_sprites().get_sword_sound_id();
 
     push_string(l, sound_id);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1728,15 +1677,14 @@ int LuaContext::hero_api_get_sword_sound_id(lua_State* l) {
  */
 int LuaContext::hero_api_set_sword_sound_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     const std::string& sound_id = LuaTools::check_string(l, 2);
 
     hero.get_hero_sprites().set_sword_sound_id(sound_id);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1746,15 +1694,14 @@ int LuaContext::hero_api_set_sword_sound_id(lua_State* l) {
  */
 int LuaContext::hero_api_get_shield_sprite_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     const std::string& sprite_id = hero.get_hero_sprites().get_shield_sprite_id();
 
     push_string(l, sprite_id);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1764,15 +1711,14 @@ int LuaContext::hero_api_get_shield_sprite_id(lua_State* l) {
  */
 int LuaContext::hero_api_set_shield_sprite_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     const std::string& sprite_id = LuaTools::check_string(l, 2);
 
     hero.get_hero_sprites().set_shield_sprite_id(sprite_id);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1782,13 +1728,12 @@ int LuaContext::hero_api_set_shield_sprite_id(lua_State* l) {
  */
 int LuaContext::hero_api_is_blinking(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     lua_pushboolean(l, hero.get_hero_sprites().is_blinking());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1798,7 +1743,7 @@ int LuaContext::hero_api_is_blinking(lua_State* l) {
  */
 int LuaContext::hero_api_set_blinking(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     bool blinking = true;
     uint32_t duration = 0;
@@ -1817,8 +1762,7 @@ int LuaContext::hero_api_set_blinking(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1828,13 +1772,12 @@ int LuaContext::hero_api_set_blinking(lua_State* l) {
  */
 int LuaContext::hero_api_is_invincible(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     lua_pushboolean(l, hero.is_invincible());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1844,7 +1787,7 @@ int LuaContext::hero_api_is_invincible(lua_State* l) {
  */
 int LuaContext::hero_api_set_invincible(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     bool invincible = true;
     uint32_t duration = 0;
@@ -1858,8 +1801,7 @@ int LuaContext::hero_api_set_invincible(lua_State* l) {
     hero.set_invincible(invincible, duration);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1869,13 +1811,12 @@ int LuaContext::hero_api_set_invincible(lua_State* l) {
  */
 int LuaContext::hero_api_get_state(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     push_string(l, hero.get_state_name());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1885,14 +1826,13 @@ int LuaContext::hero_api_get_state(lua_State* l) {
  */
 int LuaContext::hero_api_freeze(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     hero.start_freezed();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1902,14 +1842,13 @@ int LuaContext::hero_api_freeze(lua_State* l) {
  */
 int LuaContext::hero_api_unfreeze(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     hero.start_free();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1919,7 +1858,7 @@ int LuaContext::hero_api_unfreeze(lua_State* l) {
  */
 int LuaContext::hero_api_walk(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     const std::string& path = LuaTools::check_string(l, 2);
     bool loop = lua_toboolean(l, 3) != 0;
@@ -1928,8 +1867,7 @@ int LuaContext::hero_api_walk(lua_State* l) {
     hero.start_forced_walking(path, loop, ignore_obstacles);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1939,7 +1877,7 @@ int LuaContext::hero_api_walk(lua_State* l) {
  */
 int LuaContext::hero_api_start_jumping(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     int direction = LuaTools::check_int(l, 2);
     int length = LuaTools::check_int(l, 3);
@@ -1948,8 +1886,7 @@ int LuaContext::hero_api_start_jumping(lua_State* l) {
     hero.start_jumping(direction, length, ignore_obstacles, false);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1959,7 +1896,7 @@ int LuaContext::hero_api_start_jumping(lua_State* l) {
  */
 int LuaContext::hero_api_start_treasure(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     const std::string& item_name = LuaTools::check_string(l, 2);
     int variant = LuaTools::opt_int(l, 3, 1);
@@ -1989,8 +1926,7 @@ int LuaContext::hero_api_start_treasure(lua_State* l) {
     hero.start_treasure(treasure, callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2000,15 +1936,14 @@ int LuaContext::hero_api_start_treasure(lua_State* l) {
  */
 int LuaContext::hero_api_start_victory(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     ScopedLuaRef callback_ref = LuaTools::opt_function(l, 2);
 
     hero.start_victory(callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2018,7 +1953,7 @@ int LuaContext::hero_api_start_victory(lua_State* l) {
  */
 int LuaContext::hero_api_start_item(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     EquipmentItem& item = check_item(l, 2);
 
@@ -2027,8 +1962,7 @@ int LuaContext::hero_api_start_item(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2038,7 +1972,7 @@ int LuaContext::hero_api_start_item(lua_State* l) {
  */
 int LuaContext::hero_api_start_boomerang(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
     int max_distance = LuaTools::check_int(l, 2);
     int speed = LuaTools::check_int(l, 3);
@@ -2049,8 +1983,7 @@ int LuaContext::hero_api_start_boomerang(lua_State* l) {
         tunic_preparing_animation, sprite_name);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2060,14 +1993,13 @@ int LuaContext::hero_api_start_boomerang(lua_State* l) {
  */
 int LuaContext::hero_api_start_bow(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     hero.start_bow();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2077,14 +2009,13 @@ int LuaContext::hero_api_start_bow(lua_State* l) {
  */
 int LuaContext::hero_api_start_hookshot(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     hero.start_hookshot();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2094,14 +2025,13 @@ int LuaContext::hero_api_start_hookshot(lua_State* l) {
  */
 int LuaContext::hero_api_start_running(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Hero& hero = check_hero(l, 1);
 
     hero.start_running();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2111,7 +2041,7 @@ int LuaContext::hero_api_start_running(lua_State* l) {
  */
 int LuaContext::hero_api_start_hurt(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     // There are three possible prototypes:
     // - hero:start_hurt(damage)
     // - hero:start_hurt(source_x, source_y, damage)
@@ -2144,8 +2074,7 @@ int LuaContext::hero_api_start_hurt(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2187,7 +2116,7 @@ void LuaContext::notify_hero_brandish_treasure(
  */
 int LuaContext::l_treasure_dialog_finished(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     // The treasure's dialog is over.
@@ -2224,8 +2153,7 @@ int LuaContext::l_treasure_dialog_finished(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2267,7 +2195,7 @@ void LuaContext::push_teletransporter(lua_State* l, Teletransporter& teletranspo
  */
 int LuaContext::teletransporter_api_get_sound(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Teletransporter& teletransporter = check_teletransporter(l, 1);
 
     const std::string& sound_id = teletransporter.get_sound_id();
@@ -2279,8 +2207,7 @@ int LuaContext::teletransporter_api_get_sound(lua_State* l) {
       push_string(l, sound_id);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2290,7 +2217,7 @@ int LuaContext::teletransporter_api_get_sound(lua_State* l) {
  */
 int LuaContext::teletransporter_api_set_sound(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Teletransporter& teletransporter = check_teletransporter(l, 1);
 
     std::string sound_id;
@@ -2300,8 +2227,7 @@ int LuaContext::teletransporter_api_set_sound(lua_State* l) {
 
     teletransporter.set_sound_id(sound_id);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2311,15 +2237,14 @@ int LuaContext::teletransporter_api_set_sound(lua_State* l) {
  */
 int LuaContext::teletransporter_api_get_transition(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Teletransporter& teletransporter = check_teletransporter(l, 1);
 
     Transition::Style transition_style = teletransporter.get_transition_style();
 
     push_string(l, Transition::style_names[transition_style]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2329,7 +2254,7 @@ int LuaContext::teletransporter_api_get_transition(lua_State* l) {
  */
 int LuaContext::teletransporter_api_set_transition(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Teletransporter& teletransporter = check_teletransporter(l, 1);
     Transition::Style transition_style = LuaTools::check_enum<Transition::Style>(
         l, 2, Transition::style_names
@@ -2338,8 +2263,7 @@ int LuaContext::teletransporter_api_set_transition(lua_State* l) {
     teletransporter.set_transition_style(transition_style);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2349,15 +2273,14 @@ int LuaContext::teletransporter_api_set_transition(lua_State* l) {
  */
 int LuaContext::teletransporter_api_get_destination_map(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Teletransporter& teletransporter = check_teletransporter(l, 1);
 
     const std::string& map_id = teletransporter.get_destination_map_id();
 
     push_string(l, map_id);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2367,15 +2290,14 @@ int LuaContext::teletransporter_api_get_destination_map(lua_State* l) {
  */
 int LuaContext::teletransporter_api_set_destination_map(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Teletransporter& teletransporter = check_teletransporter(l, 1);
     const std::string& map_id = LuaTools::check_string(l, 2);
 
     teletransporter.set_destination_map_id(map_id);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2385,15 +2307,14 @@ int LuaContext::teletransporter_api_set_destination_map(lua_State* l) {
  */
 int LuaContext::teletransporter_api_get_destination_name(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Teletransporter& teletransporter = check_teletransporter(l, 1);
 
     const std::string& destination_name = teletransporter.get_destination_name();
 
     push_string(l, destination_name);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2403,15 +2324,14 @@ int LuaContext::teletransporter_api_get_destination_name(lua_State* l) {
  */
 int LuaContext::teletransporter_api_set_destination_name(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Teletransporter& teletransporter = check_teletransporter(l, 1);
     const std::string& destination_name = LuaTools::check_string(l, 2);
 
     teletransporter.set_destination_name(destination_name);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2485,13 +2405,12 @@ void LuaContext::push_chest(lua_State* l, Chest& chest) {
  */
 int LuaContext::chest_api_is_open(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Chest& chest = check_chest(l, 1);
 
     lua_pushboolean(l, chest.is_open());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2501,7 +2420,7 @@ int LuaContext::chest_api_is_open(lua_State* l) {
  */
 int LuaContext::chest_api_set_open(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Chest& chest = check_chest(l, 1);
     bool open = true;
     if (lua_gettop(l) >= 2) {
@@ -2511,8 +2430,7 @@ int LuaContext::chest_api_set_open(lua_State* l) {
     chest.set_open(open);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2554,14 +2472,13 @@ void LuaContext::push_block(lua_State* l, Block& block) {
  */
 int LuaContext::block_api_reset(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Block& block = check_block(l, 1);
 
     block.reset();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2571,13 +2488,12 @@ int LuaContext::block_api_reset(lua_State* l) {
  */
 int LuaContext::block_api_is_pushable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Block& block = check_block(l, 1);
 
     lua_pushboolean(l, block.is_pushable());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2587,7 +2503,7 @@ int LuaContext::block_api_is_pushable(lua_State* l) {
  */
 int LuaContext::block_api_set_pushable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Block& block = check_block(l, 1);
     bool pushable = true;
     if (lua_gettop(l) >= 2) {
@@ -2597,8 +2513,7 @@ int LuaContext::block_api_set_pushable(lua_State* l) {
     block.set_pushable(pushable);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2608,13 +2523,12 @@ int LuaContext::block_api_set_pushable(lua_State* l) {
  */
 int LuaContext::block_api_is_pullable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Block& block = check_block(l, 1);
 
     lua_pushboolean(l, block.is_pullable());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2624,7 +2538,7 @@ int LuaContext::block_api_is_pullable(lua_State* l) {
  */
 int LuaContext::block_api_set_pullable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Block& block = check_block(l, 1);
     bool pullable = true;
     if (lua_gettop(l) >= 2) {
@@ -2634,8 +2548,7 @@ int LuaContext::block_api_set_pullable(lua_State* l) {
     block.set_pullable(pullable);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2645,7 +2558,7 @@ int LuaContext::block_api_set_pullable(lua_State* l) {
  */
 int LuaContext::block_api_get_maximum_moves(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Block& block = check_block(l, 1);
 
     const int maximum_moves = block.get_maximum_moves();
@@ -2658,8 +2571,7 @@ int LuaContext::block_api_get_maximum_moves(lua_State* l) {
       lua_pushinteger(l, maximum_moves);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2669,7 +2581,7 @@ int LuaContext::block_api_get_maximum_moves(lua_State* l) {
  */
 int LuaContext::block_api_set_maximum_moves(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Block& block = check_block(l, 1);
     if (lua_type(l, 2) != LUA_TNUMBER && lua_type(l, 2) != LUA_TNIL) {
       LuaTools::type_error(l, 2, "number or nil");
@@ -2689,8 +2601,7 @@ int LuaContext::block_api_set_maximum_moves(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2732,13 +2643,12 @@ void LuaContext::push_switch(lua_State* l, Switch& sw) {
  */
 int LuaContext::switch_api_is_activated(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Switch& sw = check_switch(l, 1);
 
     lua_pushboolean(l, sw.is_activated());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2748,7 +2658,7 @@ int LuaContext::switch_api_is_activated(lua_State* l) {
  */
 int LuaContext::switch_api_set_activated(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Switch& sw = check_switch(l, 1);
     bool activated = true;
     if (lua_gettop(l) >= 2) {
@@ -2758,8 +2668,7 @@ int LuaContext::switch_api_set_activated(lua_State* l) {
     sw.set_activated(activated);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2769,7 +2678,7 @@ int LuaContext::switch_api_set_activated(lua_State* l) {
  */
 int LuaContext::switch_api_set_locked(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Switch& sw = check_switch(l, 1);
     bool locked = true;
     if (lua_gettop(l) >= 2) {
@@ -2779,8 +2688,7 @@ int LuaContext::switch_api_set_locked(lua_State* l) {
     sw.set_locked(locked);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2822,13 +2730,12 @@ void LuaContext::push_stream(lua_State* l, Stream& stream) {
  */
 int LuaContext::stream_api_get_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Stream& stream = check_stream(l, 1);
 
     lua_pushinteger(l, stream.get_direction());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2838,7 +2745,7 @@ int LuaContext::stream_api_get_direction(lua_State* l) {
  */
 int LuaContext::stream_api_set_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
     int direction = LuaTools::check_int(l, 2);
 
@@ -2849,8 +2756,7 @@ int LuaContext::stream_api_set_direction(lua_State* l) {
     stream.set_direction(direction);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2860,13 +2766,12 @@ int LuaContext::stream_api_set_direction(lua_State* l) {
  */
 int LuaContext::stream_api_get_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
 
     lua_pushinteger(l, stream.get_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2876,15 +2781,14 @@ int LuaContext::stream_api_get_speed(lua_State* l) {
  */
 int LuaContext::stream_api_set_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
     int speed = LuaTools::check_int(l, 2);
 
     stream.set_speed(speed);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2894,13 +2798,12 @@ int LuaContext::stream_api_set_speed(lua_State* l) {
  */
 int LuaContext::stream_api_get_allow_movement(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
 
     lua_pushboolean(l, stream.get_allow_movement());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2910,7 +2813,7 @@ int LuaContext::stream_api_get_allow_movement(lua_State* l) {
  */
 int LuaContext::stream_api_set_allow_movement(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
     bool allow_movement = true;
     if (lua_gettop(l) >= 2) {
@@ -2920,8 +2823,7 @@ int LuaContext::stream_api_set_allow_movement(lua_State* l) {
     stream.set_allow_movement(allow_movement);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2931,13 +2833,12 @@ int LuaContext::stream_api_set_allow_movement(lua_State* l) {
  */
 int LuaContext::stream_api_get_allow_attack(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
 
     lua_pushboolean(l, stream.get_allow_attack());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2947,7 +2848,7 @@ int LuaContext::stream_api_get_allow_attack(lua_State* l) {
  */
 int LuaContext::stream_api_set_allow_attack(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
     bool allow_attack = true;
     if (lua_gettop(l) >= 2) {
@@ -2957,8 +2858,7 @@ int LuaContext::stream_api_set_allow_attack(lua_State* l) {
     stream.set_allow_attack(allow_attack);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2968,13 +2868,12 @@ int LuaContext::stream_api_set_allow_attack(lua_State* l) {
  */
 int LuaContext::stream_api_get_allow_item(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
 
     lua_pushboolean(l, stream.get_allow_item());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2984,7 +2883,7 @@ int LuaContext::stream_api_get_allow_item(lua_State* l) {
  */
 int LuaContext::stream_api_set_allow_item(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Stream& stream = check_stream(l, 1);
     bool allow_item = true;
     if (lua_gettop(l) >= 2) {
@@ -2994,8 +2893,7 @@ int LuaContext::stream_api_set_allow_item(lua_State* l) {
     stream.set_allow_item(allow_item);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3037,13 +2935,12 @@ void LuaContext::push_door(lua_State* l, Door& door) {
  */
 int LuaContext::door_api_is_open(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Door& door = check_door(l, 1);
 
     lua_pushboolean(l, door.is_open());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3053,13 +2950,12 @@ int LuaContext::door_api_is_open(lua_State* l) {
  */
 int LuaContext::door_api_is_opening(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Door& door = check_door(l, 1);
 
     lua_pushboolean(l, door.is_opening());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3069,13 +2965,12 @@ int LuaContext::door_api_is_opening(lua_State* l) {
  */
 int LuaContext::door_api_is_closed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Door& door = check_door(l, 1);
 
     lua_pushboolean(l, door.is_closed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3085,13 +2980,12 @@ int LuaContext::door_api_is_closed(lua_State* l) {
  */
 int LuaContext::door_api_is_closing(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Door& door = check_door(l, 1);
 
     lua_pushboolean(l, door.is_closing());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3154,7 +3048,7 @@ void LuaContext::notify_shop_treasure_interaction(ShopTreasure& shop_treasure) {
  */
 int LuaContext::l_shop_treasure_description_dialog_finished(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     // The description message has just finished.
@@ -3177,8 +3071,7 @@ int LuaContext::l_shop_treasure_description_dialog_finished(lua_State* l) {
     game.start_dialog("_shop.question", price_ref, callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3189,7 +3082,7 @@ int LuaContext::l_shop_treasure_description_dialog_finished(lua_State* l) {
  */
 int LuaContext::l_shop_treasure_question_dialog_finished(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     // The "do you want to buy?" question has just been displayed.
@@ -3244,8 +3137,7 @@ int LuaContext::l_shop_treasure_question_dialog_finished(lua_State* l) {
       }
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3287,7 +3179,7 @@ void LuaContext::push_pickable(lua_State* l, Pickable& pickable) {
  */
 int LuaContext::pickable_api_get_followed_entity(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Pickable& pickable = check_pickable(l, 1);
 
     std::shared_ptr<MapEntity> followed_entity = pickable.get_entity_followed();
@@ -3299,8 +3191,7 @@ int LuaContext::pickable_api_get_followed_entity(lua_State* l) {
       lua_pushnil(l);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3310,13 +3201,12 @@ int LuaContext::pickable_api_get_followed_entity(lua_State* l) {
  */
 int LuaContext::pickable_api_get_falling_height(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Pickable& pickable = check_pickable(l, 1);
 
     lua_pushinteger(l, pickable.get_falling_height());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3326,7 +3216,7 @@ int LuaContext::pickable_api_get_falling_height(lua_State* l) {
  */
 int LuaContext::pickable_api_get_treasure(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Pickable& pickable = check_pickable(l, 1);
     const Treasure& treasure = pickable.get_treasure();
 
@@ -3339,8 +3229,7 @@ int LuaContext::pickable_api_get_treasure(lua_State* l) {
       push_string(l, treasure.get_savegame_variable());
     }
     return 3;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3382,7 +3271,7 @@ void LuaContext::push_destructible(lua_State* l, Destructible& destructible) {
  */
 int LuaContext::destructible_api_get_treasure(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
     const Treasure& treasure = destructible.get_treasure();
 
@@ -3401,8 +3290,7 @@ int LuaContext::destructible_api_get_treasure(lua_State* l) {
       push_string(l, treasure.get_savegame_variable());
     }
     return 3;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3412,7 +3300,7 @@ int LuaContext::destructible_api_get_treasure(lua_State* l) {
  */
 int LuaContext::destructible_api_set_treasure(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
     std::string item_name, savegame_variable;
     int variant = 1;
@@ -3438,8 +3326,7 @@ int LuaContext::destructible_api_set_treasure(lua_State* l) {
     destructible.set_treasure(treasure);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3449,7 +3336,7 @@ int LuaContext::destructible_api_set_treasure(lua_State* l) {
  */
 int LuaContext::destructible_api_get_destruction_sound(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
 
     const std::string& destruction_sound_id = destructible.get_destruction_sound();
@@ -3461,8 +3348,7 @@ int LuaContext::destructible_api_get_destruction_sound(lua_State* l) {
       push_string(l, destruction_sound_id);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3472,7 +3358,7 @@ int LuaContext::destructible_api_get_destruction_sound(lua_State* l) {
  */
 int LuaContext::destructible_api_set_destruction_sound(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
     std::string destruction_sound_id;
     if (!lua_isnil(l, 2)) {
@@ -3481,8 +3367,7 @@ int LuaContext::destructible_api_set_destruction_sound(lua_State* l) {
 
     destructible.set_destruction_sound(destruction_sound_id);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3492,15 +3377,14 @@ int LuaContext::destructible_api_set_destruction_sound(lua_State* l) {
  */
 int LuaContext::destructible_api_get_weight(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
 
     int weight = destructible.get_weight();
 
     lua_pushinteger(l, weight);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3510,15 +3394,14 @@ int LuaContext::destructible_api_get_weight(lua_State* l) {
  */
 int LuaContext::destructible_api_set_weight(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
     int weight = LuaTools::check_int(l, 2);
 
     destructible.set_weight(weight);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3528,15 +3411,14 @@ int LuaContext::destructible_api_set_weight(lua_State* l) {
  */
 int LuaContext::destructible_api_get_can_be_cut(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
 
     bool can_be_cut = destructible.get_can_be_cut();
 
     lua_pushboolean(l, can_be_cut);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3546,7 +3428,7 @@ int LuaContext::destructible_api_get_can_be_cut(lua_State* l) {
  */
 int LuaContext::destructible_api_set_can_be_cut(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
     bool can_be_cut = true;
     if (lua_gettop(l) >= 2) {
@@ -3555,8 +3437,7 @@ int LuaContext::destructible_api_set_can_be_cut(lua_State* l) {
     destructible.set_can_be_cut(can_be_cut);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3566,15 +3447,14 @@ int LuaContext::destructible_api_set_can_be_cut(lua_State* l) {
  */
 int LuaContext::destructible_api_get_can_explode(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
 
     bool can_explode = destructible.get_can_explode();
 
     lua_pushboolean(l, can_explode);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3584,7 +3464,7 @@ int LuaContext::destructible_api_get_can_explode(lua_State* l) {
  */
 int LuaContext::destructible_api_set_can_explode(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
     bool can_explode = true;
     if (lua_gettop(l) >= 2) {
@@ -3593,8 +3473,7 @@ int LuaContext::destructible_api_set_can_explode(lua_State* l) {
     destructible.set_can_explode(can_explode);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3604,15 +3483,14 @@ int LuaContext::destructible_api_set_can_explode(lua_State* l) {
  */
 int LuaContext::destructible_api_get_can_regenerate(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
 
     bool can_regenerate = destructible.get_can_regenerate();
 
     lua_pushboolean(l, can_regenerate);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3622,7 +3500,7 @@ int LuaContext::destructible_api_get_can_regenerate(lua_State* l) {
  */
 int LuaContext::destructible_api_set_can_regenerate(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
     bool can_regenerate = true;
     if (lua_gettop(l) >= 2) {
@@ -3631,8 +3509,7 @@ int LuaContext::destructible_api_set_can_regenerate(lua_State* l) {
     destructible.set_can_regenerate(can_regenerate);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3642,15 +3519,14 @@ int LuaContext::destructible_api_set_can_regenerate(lua_State* l) {
  */
 int LuaContext::destructible_api_get_damage_on_enemies(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
 
     int damage_on_enemies = destructible.get_damage_on_enemies();
 
     lua_pushinteger(l, damage_on_enemies);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3660,15 +3536,14 @@ int LuaContext::destructible_api_get_damage_on_enemies(lua_State* l) {
  */
 int LuaContext::destructible_api_set_damage_on_enemies(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
     int damage_on_enemies = LuaTools::check_int(l, 2);
 
     destructible.set_damage_on_enemies(damage_on_enemies);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3678,15 +3553,14 @@ int LuaContext::destructible_api_set_damage_on_enemies(lua_State* l) {
  */
 int LuaContext::destructible_api_get_modified_ground(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Destructible& destructible = check_destructible(l, 1);
 
     Ground modified_ground = destructible.get_modified_ground();
 
     push_string(l, Tileset::ground_names[modified_ground]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3728,13 +3602,12 @@ void LuaContext::push_enemy(lua_State* l, Enemy& enemy) {
  */
 int LuaContext::enemy_api_get_breed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     push_string(l, enemy.get_breed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3744,13 +3617,12 @@ int LuaContext::enemy_api_get_breed(lua_State* l) {
  */
 int LuaContext::enemy_api_get_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     lua_pushinteger(l, enemy.get_life());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3760,15 +3632,14 @@ int LuaContext::enemy_api_get_life(lua_State* l) {
  */
 int LuaContext::enemy_api_set_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     int life = LuaTools::check_int(l, 2);
 
     enemy.set_life(life);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3778,15 +3649,14 @@ int LuaContext::enemy_api_set_life(lua_State* l) {
  */
 int LuaContext::enemy_api_add_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     int points = LuaTools::check_int(l, 2);
 
     enemy.set_life(enemy.get_life() + points);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3796,15 +3666,14 @@ int LuaContext::enemy_api_add_life(lua_State* l) {
  */
 int LuaContext::enemy_api_remove_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     int points = LuaTools::check_int(l, 2);
 
     enemy.set_life(enemy.get_life() - points);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3814,13 +3683,12 @@ int LuaContext::enemy_api_remove_life(lua_State* l) {
  */
 int LuaContext::enemy_api_get_damage(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     lua_pushinteger(l, enemy.get_damage());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3830,15 +3698,14 @@ int LuaContext::enemy_api_get_damage(lua_State* l) {
  */
 int LuaContext::enemy_api_set_damage(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     int damage = LuaTools::check_int(l, 2);
 
     enemy.set_damage(damage);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3848,13 +3715,12 @@ int LuaContext::enemy_api_set_damage(lua_State* l) {
  */
 int LuaContext::enemy_api_is_pushed_back_when_hurt(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     lua_pushboolean(l, enemy.get_pushed_back_when_hurt());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3864,7 +3730,7 @@ int LuaContext::enemy_api_is_pushed_back_when_hurt(lua_State* l) {
  */
 int LuaContext::enemy_api_set_pushed_back_when_hurt(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     bool push_back = true;
     if (lua_gettop(l) >= 2) {
@@ -3874,8 +3740,7 @@ int LuaContext::enemy_api_set_pushed_back_when_hurt(lua_State* l) {
     enemy.set_pushed_back_when_hurt(push_back);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3885,13 +3750,12 @@ int LuaContext::enemy_api_set_pushed_back_when_hurt(lua_State* l) {
  */
 int LuaContext::enemy_api_get_push_hero_on_sword(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     lua_pushboolean(l, enemy.get_push_hero_on_sword());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3901,7 +3765,7 @@ int LuaContext::enemy_api_get_push_hero_on_sword(lua_State* l) {
  */
 int LuaContext::enemy_api_set_push_hero_on_sword(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     bool push = true;
     if (lua_gettop(l) >= 2) {
@@ -3911,8 +3775,7 @@ int LuaContext::enemy_api_set_push_hero_on_sword(lua_State* l) {
     enemy.set_push_hero_on_sword(push);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3922,13 +3785,12 @@ int LuaContext::enemy_api_set_push_hero_on_sword(lua_State* l) {
  */
 int LuaContext::enemy_api_get_can_hurt_hero_running(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     lua_pushboolean(l, enemy.get_can_hurt_hero_running());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3938,7 +3800,7 @@ int LuaContext::enemy_api_get_can_hurt_hero_running(lua_State* l) {
  */
 int LuaContext::enemy_api_set_can_hurt_hero_running(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     bool can_hurt_hero_running = true;
     if (lua_gettop(l) >= 2) {
@@ -3948,8 +3810,7 @@ int LuaContext::enemy_api_set_can_hurt_hero_running(lua_State* l) {
     enemy.set_can_hurt_hero_running(can_hurt_hero_running);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3959,15 +3820,14 @@ int LuaContext::enemy_api_set_can_hurt_hero_running(lua_State* l) {
  */
 int LuaContext::enemy_api_get_hurt_style(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     Enemy::HurtStyle hurt_style = enemy.get_hurt_style();
 
     push_string(l, Enemy::hurt_style_names[hurt_style]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3977,7 +3837,7 @@ int LuaContext::enemy_api_get_hurt_style(lua_State* l) {
  */
 int LuaContext::enemy_api_set_hurt_style(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     Enemy::HurtStyle hurt_style = LuaTools::check_enum<Enemy::HurtStyle>(
         l, 2, Enemy::hurt_style_names);
@@ -3985,8 +3845,7 @@ int LuaContext::enemy_api_set_hurt_style(lua_State* l) {
     enemy.set_hurt_style(hurt_style);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -3996,13 +3855,12 @@ int LuaContext::enemy_api_set_hurt_style(lua_State* l) {
  */
 int LuaContext::enemy_api_get_can_attack(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     lua_pushboolean(l, enemy.get_can_attack());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4012,7 +3870,7 @@ int LuaContext::enemy_api_get_can_attack(lua_State* l) {
  */
 int LuaContext::enemy_api_set_can_attack(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     bool can_attack = true;
     if (lua_gettop(l) >= 2) {
@@ -4022,8 +3880,7 @@ int LuaContext::enemy_api_set_can_attack(lua_State* l) {
     enemy.set_can_attack(can_attack);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4033,15 +3890,14 @@ int LuaContext::enemy_api_set_can_attack(lua_State* l) {
  */
 int LuaContext::enemy_api_get_minimum_shield_needed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     int shield_level = enemy.get_minimum_shield_needed();
 
     lua_pushinteger(l, shield_level);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4051,15 +3907,14 @@ int LuaContext::enemy_api_get_minimum_shield_needed(lua_State* l) {
  */
 int LuaContext::enemy_api_set_minimum_shield_needed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     int shield_level = LuaTools::check_int(l, 2);
 
     enemy.set_minimum_shield_needed(shield_level);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4069,7 +3924,7 @@ int LuaContext::enemy_api_set_minimum_shield_needed(lua_State* l) {
  */
 int LuaContext::enemy_api_get_attack_consequence(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     EnemyAttack attack = LuaTools::check_enum<EnemyAttack>(l, 2, Enemy::attack_names);
 
@@ -4083,8 +3938,7 @@ int LuaContext::enemy_api_get_attack_consequence(lua_State* l) {
       push_string(l, EnemyReaction::get_reaction_name(reaction.type));
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4094,7 +3948,7 @@ int LuaContext::enemy_api_get_attack_consequence(lua_State* l) {
  */
 int LuaContext::enemy_api_set_attack_consequence(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     EnemyAttack attack = LuaTools::check_enum<EnemyAttack>(l, 2, Enemy::attack_names);
 
@@ -4115,8 +3969,7 @@ int LuaContext::enemy_api_set_attack_consequence(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4126,7 +3979,7 @@ int LuaContext::enemy_api_set_attack_consequence(lua_State* l) {
  */
 int LuaContext::enemy_api_get_attack_consequence_sprite(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     Sprite& sprite = *check_sprite(l, 2);
     EnemyAttack attack = LuaTools::check_enum<EnemyAttack>(l, 3, Enemy::attack_names);
@@ -4141,8 +3994,7 @@ int LuaContext::enemy_api_get_attack_consequence_sprite(lua_State* l) {
       push_string(l, EnemyReaction::get_reaction_name(reaction.type));
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4152,7 +4004,7 @@ int LuaContext::enemy_api_get_attack_consequence_sprite(lua_State* l) {
  */
 int LuaContext::enemy_api_set_attack_consequence_sprite(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     Sprite& sprite = *check_sprite(l, 2);
     EnemyAttack attack = LuaTools::check_enum<EnemyAttack>(l, 3, Enemy::attack_names);
@@ -4174,8 +4026,7 @@ int LuaContext::enemy_api_set_attack_consequence_sprite(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4185,14 +4036,13 @@ int LuaContext::enemy_api_set_attack_consequence_sprite(lua_State* l) {
  */
 int LuaContext::enemy_api_set_default_attack_consequences(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     enemy.set_default_attack_consequences();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4202,15 +4052,14 @@ int LuaContext::enemy_api_set_default_attack_consequences(lua_State* l) {
  */
 int LuaContext::enemy_api_set_default_attack_consequences_sprite(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     Sprite& sprite = *check_sprite(l, 2);
 
     enemy.set_default_attack_consequences_sprite(sprite);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4220,14 +4069,13 @@ int LuaContext::enemy_api_set_default_attack_consequences_sprite(lua_State* l) {
  */
 int LuaContext::enemy_api_set_invincible(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     enemy.set_no_attack_consequences();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4237,15 +4085,14 @@ int LuaContext::enemy_api_set_invincible(lua_State* l) {
  */
 int LuaContext::enemy_api_set_invincible_sprite(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     Sprite& sprite = *check_sprite(l, 2);
 
     enemy.set_no_attack_consequences_sprite(sprite);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4255,7 +4102,7 @@ int LuaContext::enemy_api_set_invincible_sprite(lua_State* l) {
  */
 int LuaContext::enemy_api_get_treasure(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     const Treasure& treasure = enemy.get_treasure();
 
@@ -4274,8 +4121,7 @@ int LuaContext::enemy_api_get_treasure(lua_State* l) {
       push_string(l, treasure.get_savegame_variable());
     }
     return 3;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 
@@ -4286,7 +4132,7 @@ int LuaContext::enemy_api_get_treasure(lua_State* l) {
  */
 int LuaContext::enemy_api_set_treasure(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     std::string item_name, savegame_variable;
     int variant = 1;
@@ -4312,8 +4158,7 @@ int LuaContext::enemy_api_set_treasure(lua_State* l) {
     enemy.set_treasure(treasure);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4323,13 +4168,12 @@ int LuaContext::enemy_api_set_treasure(lua_State* l) {
  */
 int LuaContext::enemy_api_is_traversable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     lua_pushboolean(l, enemy.is_traversable());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4339,7 +4183,7 @@ int LuaContext::enemy_api_is_traversable(lua_State* l) {
  */
 int LuaContext::enemy_api_set_traversable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     bool traversable = true;
@@ -4350,8 +4194,7 @@ int LuaContext::enemy_api_set_traversable(lua_State* l) {
     enemy.set_traversable(traversable);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4361,15 +4204,14 @@ int LuaContext::enemy_api_set_traversable(lua_State* l) {
  */
 int LuaContext::enemy_api_get_obstacle_behavior(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     Enemy::ObstacleBehavior behavior = enemy.get_obstacle_behavior();
 
     push_string(l, Enemy::obstacle_behavior_names[behavior]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4379,7 +4221,7 @@ int LuaContext::enemy_api_get_obstacle_behavior(lua_State* l) {
  */
 int LuaContext::enemy_api_set_obstacle_behavior(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     Enemy::ObstacleBehavior behavior = LuaTools::check_enum<Enemy::ObstacleBehavior>(
         l, 2, Enemy::obstacle_behavior_names);
@@ -4387,8 +4229,7 @@ int LuaContext::enemy_api_set_obstacle_behavior(lua_State* l) {
     enemy.set_obstacle_behavior(behavior);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4398,14 +4239,13 @@ int LuaContext::enemy_api_set_obstacle_behavior(lua_State* l) {
  */
 int LuaContext::enemy_api_restart(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     enemy.restart();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4415,7 +4255,7 @@ int LuaContext::enemy_api_restart(lua_State* l) {
  */
 int LuaContext::enemy_api_hurt(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     int life_points = LuaTools::check_int(l, 2);
 
@@ -4426,8 +4266,7 @@ int LuaContext::enemy_api_hurt(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4437,7 +4276,7 @@ int LuaContext::enemy_api_hurt(lua_State* l) {
  */
 int LuaContext::enemy_api_immobilize(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
 
     if (enemy.is_in_normal_state() && !enemy.is_invulnerable()) {
@@ -4447,8 +4286,7 @@ int LuaContext::enemy_api_immobilize(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4458,7 +4296,7 @@ int LuaContext::enemy_api_immobilize(lua_State* l) {
  */
 int LuaContext::enemy_api_create_enemy(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Enemy& enemy = check_enemy(l, 1);
     LuaTools::check_type(l, 2, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 2, "name", "");
@@ -4525,8 +4363,7 @@ int LuaContext::enemy_api_create_enemy(lua_State* l) {
 
     push_entity(l, *entity);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4687,13 +4524,12 @@ void LuaContext::do_custom_entity_collision_callback(
  */
 int LuaContext::custom_entity_api_get_model(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
 
     push_string(l, entity.get_model());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4703,13 +4539,12 @@ int LuaContext::custom_entity_api_get_model(lua_State* l) {
  */
 int LuaContext::custom_entity_api_get_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const CustomEntity& entity = check_custom_entity(l, 1);
 
     lua_pushinteger(l, entity.get_sprites_direction());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4719,15 +4554,14 @@ int LuaContext::custom_entity_api_get_direction(lua_State* l) {
  */
 int LuaContext::custom_entity_api_set_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
     int direction = LuaTools::check_int(l, 2);
 
     entity.set_sprites_direction(direction);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4737,13 +4571,12 @@ int LuaContext::custom_entity_api_set_direction(lua_State* l) {
  */
 int LuaContext::custom_entity_api_is_drawn_in_y_order(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const CustomEntity& entity = check_custom_entity(l, 1);
 
     lua_pushboolean(l, entity.is_drawn_in_y_order());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4753,7 +4586,7 @@ int LuaContext::custom_entity_api_is_drawn_in_y_order(lua_State* l) {
  */
 int LuaContext::custom_entity_api_set_drawn_in_y_order(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
     bool y_order = true;
     if (lua_gettop(l) >= 2) {
@@ -4763,8 +4596,7 @@ int LuaContext::custom_entity_api_set_drawn_in_y_order(lua_State* l) {
     entity.set_drawn_in_y_order(y_order);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4774,7 +4606,7 @@ int LuaContext::custom_entity_api_set_drawn_in_y_order(lua_State* l) {
  */
 int LuaContext::custom_entity_api_set_traversable_by(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
 
     bool type_specific = false;
@@ -4823,8 +4655,7 @@ int LuaContext::custom_entity_api_set_traversable_by(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4834,7 +4665,7 @@ int LuaContext::custom_entity_api_set_traversable_by(lua_State* l) {
  */
 int LuaContext::custom_entity_api_set_can_traverse(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
 
     bool type_specific = false;
@@ -4883,8 +4714,7 @@ int LuaContext::custom_entity_api_set_can_traverse(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4894,7 +4724,7 @@ int LuaContext::custom_entity_api_set_can_traverse(lua_State* l) {
  */
 int LuaContext::custom_entity_api_can_traverse_ground(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
     Ground ground = LuaTools::check_enum<Ground>(
         l, 2, Tileset::ground_names
@@ -4904,8 +4734,7 @@ int LuaContext::custom_entity_api_can_traverse_ground(lua_State* l) {
 
     lua_pushboolean(l, traversable);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4915,7 +4744,7 @@ int LuaContext::custom_entity_api_can_traverse_ground(lua_State* l) {
  */
 int LuaContext::custom_entity_api_set_can_traverse_ground(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
     Ground ground = LuaTools::check_enum<Ground>(
         l, 2, Tileset::ground_names
@@ -4933,8 +4762,7 @@ int LuaContext::custom_entity_api_set_can_traverse_ground(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -4944,7 +4772,7 @@ int LuaContext::custom_entity_api_set_can_traverse_ground(lua_State* l) {
  */
 int LuaContext::custom_entity_api_add_collision_test(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
 
     const ScopedLuaRef& callback_ref = LuaTools::check_function(l, 3);
@@ -4996,8 +4824,7 @@ int LuaContext::custom_entity_api_add_collision_test(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -5007,14 +4834,13 @@ int LuaContext::custom_entity_api_add_collision_test(lua_State* l) {
  */
 int LuaContext::custom_entity_api_clear_collision_tests(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
 
     entity.clear_collision_tests();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -5024,7 +4850,7 @@ int LuaContext::custom_entity_api_clear_collision_tests(lua_State* l) {
  */
 int LuaContext::custom_entity_api_get_modified_ground(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const CustomEntity& entity = check_custom_entity(l, 1);
 
     const Ground modified_ground = entity.get_modified_ground();
@@ -5036,8 +4862,7 @@ int LuaContext::custom_entity_api_get_modified_ground(lua_State* l) {
       push_string(l, Tileset::ground_names[modified_ground]);
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -5047,7 +4872,7 @@ int LuaContext::custom_entity_api_get_modified_ground(lua_State* l) {
  */
 int LuaContext::custom_entity_api_set_modified_ground(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CustomEntity& entity = check_custom_entity(l, 1);
     Ground modified_ground = GROUND_EMPTY;
 
@@ -5059,8 +4884,7 @@ int LuaContext::custom_entity_api_set_modified_ground(lua_State* l) {
 
     entity.set_modified_ground(modified_ground);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/FileApi.cpp
+++ b/src/lua/FileApi.cpp
@@ -60,7 +60,7 @@ void LuaContext::register_file_module() {
  */
 int LuaContext::file_api_open(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& file_name = LuaTools::check_string(l, 1);
     const std::string& mode = LuaTools::opt_string(l, 2, "r");
 
@@ -129,8 +129,7 @@ int LuaContext::file_api_open(lua_State* l) {
     }
 
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -140,14 +139,13 @@ int LuaContext::file_api_open(lua_State* l) {
  */
 int LuaContext::file_api_exists(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& file_name = LuaTools::check_string(l, 1);
 
     lua_pushboolean(l, FileTools::data_file_exists(file_name, false));
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -157,7 +155,7 @@ int LuaContext::file_api_exists(lua_State* l) {
  */
 int LuaContext::file_api_remove(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& file_name = LuaTools::check_string(l, 1);
 
     bool success = FileTools::data_file_delete(file_name);
@@ -170,8 +168,7 @@ int LuaContext::file_api_remove(lua_State* l) {
 
     lua_pushboolean(l, true);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -181,7 +178,7 @@ int LuaContext::file_api_remove(lua_State* l) {
  */
 int LuaContext::file_api_mkdir(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& dir_name = LuaTools::check_string(l, 1);
 
     bool success = FileTools::data_file_mkdir(dir_name);
@@ -194,8 +191,7 @@ int LuaContext::file_api_mkdir(lua_State* l) {
 
     lua_pushboolean(l, true);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lua/GameApi.cpp
+++ b/src/lua/GameApi.cpp
@@ -157,7 +157,7 @@ void LuaContext::push_game(lua_State* l, Savegame& game) {
  */
 int LuaContext::game_api_exists(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& file_name = LuaTools::check_string(l, 1);
 
     if (FileTools::get_quest_write_dir().empty()) {
@@ -168,8 +168,7 @@ int LuaContext::game_api_exists(lua_State* l) {
 
     lua_pushboolean(l, exists);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -179,7 +178,7 @@ int LuaContext::game_api_exists(lua_State* l) {
  */
 int LuaContext::game_api_delete(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& file_name = LuaTools::check_string(l, 1);
 
     if (FileTools::get_quest_write_dir().empty()) {
@@ -189,8 +188,7 @@ int LuaContext::game_api_delete(lua_State* l) {
     FileTools::data_file_delete(file_name);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -200,7 +198,7 @@ int LuaContext::game_api_delete(lua_State* l) {
  */
 int LuaContext::game_api_load(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& file_name = LuaTools::check_string(l, 1);
 
     if (FileTools::get_quest_write_dir().empty()) {
@@ -215,8 +213,7 @@ int LuaContext::game_api_load(lua_State* l) {
 
     push_game(l, *savegame);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -226,7 +223,7 @@ int LuaContext::game_api_load(lua_State* l) {
  */
 int LuaContext::game_api_save(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     if (FileTools::get_quest_write_dir().empty()) {
@@ -236,8 +233,7 @@ int LuaContext::game_api_save(lua_State* l) {
     savegame.save();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -247,7 +243,7 @@ int LuaContext::game_api_save(lua_State* l) {
  */
 int LuaContext::game_api_start(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Savegame> savegame = check_game(l, 1);
 
     if (QuestResourceList::get_elements(QuestResourceList::RESOURCE_MAP).empty()) {
@@ -267,8 +263,7 @@ int LuaContext::game_api_start(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -278,7 +273,7 @@ int LuaContext::game_api_start(lua_State* l) {
  */
 int LuaContext::game_api_is_started(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -286,8 +281,7 @@ int LuaContext::game_api_is_started(lua_State* l) {
 
     lua_pushboolean(l, is_started);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -297,7 +291,7 @@ int LuaContext::game_api_is_started(lua_State* l) {
  */
 int LuaContext::game_api_is_suspended(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -305,8 +299,7 @@ int LuaContext::game_api_is_suspended(lua_State* l) {
 
     lua_pushboolean(l, is_suspended);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -316,7 +309,7 @@ int LuaContext::game_api_is_suspended(lua_State* l) {
  */
 int LuaContext::game_api_is_paused(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -324,8 +317,7 @@ int LuaContext::game_api_is_paused(lua_State* l) {
 
     lua_pushboolean(l, is_paused);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -335,7 +327,7 @@ int LuaContext::game_api_is_paused(lua_State* l) {
  */
 int LuaContext::game_api_set_paused(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     bool paused = true;
     if (lua_gettop(l) >= 2) {
@@ -348,8 +340,7 @@ int LuaContext::game_api_set_paused(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -359,7 +350,7 @@ int LuaContext::game_api_set_paused(lua_State* l) {
  */
 int LuaContext::game_api_is_pause_allowed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -367,8 +358,7 @@ int LuaContext::game_api_is_pause_allowed(lua_State* l) {
 
     lua_pushboolean(l, is_pause_allowed);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -378,7 +368,7 @@ int LuaContext::game_api_is_pause_allowed(lua_State* l) {
  */
 int LuaContext::game_api_set_pause_allowed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     bool pause_allowed = true;
@@ -392,8 +382,7 @@ int LuaContext::game_api_set_pause_allowed(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -403,7 +392,7 @@ int LuaContext::game_api_set_pause_allowed(lua_State* l) {
  */
 int LuaContext::game_api_is_dialog_enabled(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -414,8 +403,7 @@ int LuaContext::game_api_is_dialog_enabled(lua_State* l) {
       lua_pushboolean(l, game->is_dialog_enabled());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -425,7 +413,7 @@ int LuaContext::game_api_is_dialog_enabled(lua_State* l) {
  */
 int LuaContext::game_api_start_dialog(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     const std::string& dialog_id = LuaTools::check_string(l, 2);
     ScopedLuaRef info_ref;
@@ -460,8 +448,7 @@ int LuaContext::game_api_start_dialog(lua_State* l) {
     game->start_dialog(dialog_id, info_ref, callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -471,7 +458,7 @@ int LuaContext::game_api_start_dialog(lua_State* l) {
  */
 int LuaContext::game_api_stop_dialog(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -493,8 +480,7 @@ int LuaContext::game_api_stop_dialog(lua_State* l) {
     game->stop_dialog(status_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -504,7 +490,7 @@ int LuaContext::game_api_stop_dialog(lua_State* l) {
  */
 int LuaContext::game_api_is_game_over_enabled(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -515,8 +501,7 @@ int LuaContext::game_api_is_game_over_enabled(lua_State* l) {
       lua_pushboolean(l, game->is_showing_game_over());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -526,7 +511,7 @@ int LuaContext::game_api_is_game_over_enabled(lua_State* l) {
  */
 int LuaContext::game_api_start_game_over(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -537,8 +522,7 @@ int LuaContext::game_api_start_game_over(lua_State* l) {
     game->start_game_over();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -548,7 +532,7 @@ int LuaContext::game_api_start_game_over(lua_State* l) {
  */
 int LuaContext::game_api_stop_game_over(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -559,8 +543,7 @@ int LuaContext::game_api_stop_game_over(lua_State* l) {
     game->stop_game_over();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -570,7 +553,7 @@ int LuaContext::game_api_stop_game_over(lua_State* l) {
  */
 int LuaContext::game_api_get_map(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -581,8 +564,7 @@ int LuaContext::game_api_get_map(lua_State* l) {
       push_map(l, game->get_current_map());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -592,7 +574,7 @@ int LuaContext::game_api_get_map(lua_State* l) {
  */
 int LuaContext::game_api_get_hero(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     Game* game = savegame.get_game();
@@ -603,8 +585,7 @@ int LuaContext::game_api_get_hero(lua_State* l) {
       push_hero(l, *game->get_hero());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -614,7 +595,7 @@ int LuaContext::game_api_get_hero(lua_State* l) {
  */
 int LuaContext::game_api_get_value(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     const std::string& key = LuaTools::check_string(l, 2);
 
@@ -639,8 +620,7 @@ int LuaContext::game_api_get_value(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -650,7 +630,7 @@ int LuaContext::game_api_get_value(lua_State* l) {
  */
 int LuaContext::game_api_set_value(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     const std::string& key = LuaTools::check_string(l, 2);
 
@@ -693,8 +673,7 @@ int LuaContext::game_api_set_value(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -704,7 +683,7 @@ int LuaContext::game_api_set_value(lua_State* l) {
  */
 int LuaContext::game_api_get_starting_location(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     const std::string& starting_map = savegame.get_string(Savegame::KEY_STARTING_MAP);
@@ -723,8 +702,7 @@ int LuaContext::game_api_get_starting_location(lua_State* l) {
       push_string(l, savegame.get_string(Savegame::KEY_STARTING_POINT));
     }
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -734,7 +712,7 @@ int LuaContext::game_api_get_starting_location(lua_State* l) {
  */
 int LuaContext::game_api_set_starting_location(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     const std::string& map_id = LuaTools::check_string(l, 2);
     const std::string& destination_name = LuaTools::opt_string(l, 3, "");
@@ -743,8 +721,7 @@ int LuaContext::game_api_set_starting_location(lua_State* l) {
     savegame.set_string(Savegame::KEY_STARTING_POINT, destination_name);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -754,14 +731,13 @@ int LuaContext::game_api_set_starting_location(lua_State* l) {
  */
 int LuaContext::game_api_get_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     int life = savegame.get_equipment().get_life();
     lua_pushinteger(l, life);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -771,15 +747,14 @@ int LuaContext::game_api_get_life(lua_State* l) {
  */
 int LuaContext::game_api_set_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int life = LuaTools::check_int(l, 2);
 
     savegame.get_equipment().set_life(life);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -789,7 +764,7 @@ int LuaContext::game_api_set_life(lua_State* l) {
  */
 int LuaContext::game_api_add_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int life = LuaTools::check_int(l, 2);
 
@@ -800,8 +775,7 @@ int LuaContext::game_api_add_life(lua_State* l) {
     savegame.get_equipment().add_life(life);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -811,7 +785,7 @@ int LuaContext::game_api_add_life(lua_State* l) {
  */
 int LuaContext::game_api_remove_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int life = LuaTools::check_int(l, 2);
 
@@ -822,8 +796,7 @@ int LuaContext::game_api_remove_life(lua_State* l) {
     savegame.get_equipment().remove_life(life);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -833,15 +806,14 @@ int LuaContext::game_api_remove_life(lua_State* l) {
  */
 int LuaContext::game_api_get_max_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     int life = savegame.get_equipment().get_max_life();
 
     lua_pushinteger(l, life);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -851,7 +823,7 @@ int LuaContext::game_api_get_max_life(lua_State* l) {
  */
 int LuaContext::game_api_set_max_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int life = LuaTools::check_int(l, 2);
 
@@ -862,8 +834,7 @@ int LuaContext::game_api_set_max_life(lua_State* l) {
     savegame.get_equipment().set_max_life(life);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -873,7 +844,7 @@ int LuaContext::game_api_set_max_life(lua_State* l) {
  */
 int LuaContext::game_api_add_max_life(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int life = LuaTools::check_int(l, 2);
 
@@ -885,8 +856,7 @@ int LuaContext::game_api_add_max_life(lua_State* l) {
     equipment.set_max_life(equipment.get_max_life() + life);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -896,15 +866,14 @@ int LuaContext::game_api_add_max_life(lua_State* l) {
  */
 int LuaContext::game_api_get_money(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     int money = savegame.get_equipment().get_money();
 
     lua_pushinteger(l, money);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -914,15 +883,14 @@ int LuaContext::game_api_get_money(lua_State* l) {
  */
 int LuaContext::game_api_set_money(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int money = LuaTools::check_int(l, 2);
 
     savegame.get_equipment().set_money(money);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -932,7 +900,7 @@ int LuaContext::game_api_set_money(lua_State* l) {
  */
 int LuaContext::game_api_add_money(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int money = LuaTools::check_int(l, 2);
 
@@ -943,8 +911,7 @@ int LuaContext::game_api_add_money(lua_State* l) {
     savegame.get_equipment().add_money(money);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -954,7 +921,7 @@ int LuaContext::game_api_add_money(lua_State* l) {
  */
 int LuaContext::game_api_remove_money(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int money = LuaTools::check_int(l, 2);
 
@@ -965,8 +932,7 @@ int LuaContext::game_api_remove_money(lua_State* l) {
     savegame.get_equipment().remove_money(money);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -976,15 +942,14 @@ int LuaContext::game_api_remove_money(lua_State* l) {
  */
 int LuaContext::game_api_get_max_money(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     int money = savegame.get_equipment().get_max_money();
 
     lua_pushinteger(l, money);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -994,7 +959,7 @@ int LuaContext::game_api_get_max_money(lua_State* l) {
  */
 int LuaContext::game_api_set_max_money(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int money = LuaTools::check_int(l, 2);
 
@@ -1005,8 +970,7 @@ int LuaContext::game_api_set_max_money(lua_State* l) {
     savegame.get_equipment().set_max_money(money);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1016,15 +980,14 @@ int LuaContext::game_api_set_max_money(lua_State* l) {
  */
 int LuaContext::game_api_get_magic(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     int magic = savegame.get_equipment().get_magic();
 
     lua_pushinteger(l, magic);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1034,15 +997,14 @@ int LuaContext::game_api_get_magic(lua_State* l) {
  */
 int LuaContext::game_api_set_magic(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int magic = LuaTools::check_int(l, 2);
 
     savegame.get_equipment().set_magic(magic);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1052,7 +1014,7 @@ int LuaContext::game_api_set_magic(lua_State* l) {
  */
 int LuaContext::game_api_add_magic(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int magic = LuaTools::check_int(l, 2);
 
@@ -1063,8 +1025,7 @@ int LuaContext::game_api_add_magic(lua_State* l) {
     savegame.get_equipment().add_magic(magic);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1074,7 +1035,7 @@ int LuaContext::game_api_add_magic(lua_State* l) {
  */
 int LuaContext::game_api_remove_magic(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int magic = LuaTools::check_int(l, 2);
 
@@ -1085,8 +1046,7 @@ int LuaContext::game_api_remove_magic(lua_State* l) {
     savegame.get_equipment().remove_magic(magic);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1096,15 +1056,14 @@ int LuaContext::game_api_remove_magic(lua_State* l) {
  */
 int LuaContext::game_api_get_max_magic(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     int magic = savegame.get_equipment().get_max_magic();
 
     lua_pushinteger(l, magic);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1114,7 +1073,7 @@ int LuaContext::game_api_get_max_magic(lua_State* l) {
  */
 int LuaContext::game_api_set_max_magic(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int magic = LuaTools::check_int(l, 2);
 
@@ -1125,8 +1084,7 @@ int LuaContext::game_api_set_max_magic(lua_State* l) {
     savegame.get_equipment().set_max_magic(magic);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1136,7 +1094,7 @@ int LuaContext::game_api_set_max_magic(lua_State* l) {
  */
 int LuaContext::game_api_has_ability(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     Ability ability = LuaTools::check_enum<Ability>(l, 2, Equipment::ability_names);
 
@@ -1144,8 +1102,7 @@ int LuaContext::game_api_has_ability(lua_State* l) {
 
     lua_pushboolean(l, has_ability);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1155,7 +1112,7 @@ int LuaContext::game_api_has_ability(lua_State* l) {
  */
 int LuaContext::game_api_get_ability(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     Ability ability = LuaTools::check_enum<Ability>(l, 2, Equipment::ability_names);
 
@@ -1163,8 +1120,7 @@ int LuaContext::game_api_get_ability(lua_State* l) {
 
     lua_pushinteger(l, ability_level);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1174,7 +1130,7 @@ int LuaContext::game_api_get_ability(lua_State* l) {
  */
 int LuaContext::game_api_set_ability(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     Ability ability = LuaTools::check_enum<Ability>(l, 2, Equipment::ability_names);
     int level = LuaTools::check_int(l, 3);
@@ -1182,8 +1138,7 @@ int LuaContext::game_api_set_ability(lua_State* l) {
     savegame.get_equipment().set_ability(ability, level);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1193,7 +1148,7 @@ int LuaContext::game_api_set_ability(lua_State* l) {
  */
 int LuaContext::game_api_get_item(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     const std::string& item_name = LuaTools::check_string(l, 2);
 
@@ -1203,8 +1158,7 @@ int LuaContext::game_api_get_item(lua_State* l) {
 
     push_item(l, savegame.get_equipment().get_item(item_name));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1214,7 +1168,7 @@ int LuaContext::game_api_get_item(lua_State* l) {
  */
 int LuaContext::game_api_has_item(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     const std::string& item_name = LuaTools::check_string(l, 2);
 
@@ -1229,8 +1183,7 @@ int LuaContext::game_api_has_item(lua_State* l) {
 
     lua_pushboolean(l, equipment.get_item(item_name).get_variant() > 0);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1240,7 +1193,7 @@ int LuaContext::game_api_has_item(lua_State* l) {
  */
 int LuaContext::game_api_get_item_assigned(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int slot = LuaTools::check_int(l, 2);
 
@@ -1257,8 +1210,7 @@ int LuaContext::game_api_get_item_assigned(lua_State* l) {
       push_item(l, *item);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1268,7 +1220,7 @@ int LuaContext::game_api_get_item_assigned(lua_State* l) {
  */
 int LuaContext::game_api_set_item_assigned(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     int slot = LuaTools::check_int(l, 2);
     EquipmentItem* item = nullptr;
@@ -1283,8 +1235,7 @@ int LuaContext::game_api_set_item_assigned(lua_State* l) {
     savegame.get_equipment().set_item_assigned(slot, item);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1294,7 +1245,7 @@ int LuaContext::game_api_set_item_assigned(lua_State* l) {
  */
 int LuaContext::game_api_get_command_effect(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1378,8 +1329,7 @@ int LuaContext::game_api_get_command_effect(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1389,7 +1339,7 @@ int LuaContext::game_api_get_command_effect(lua_State* l) {
  */
 int LuaContext::game_api_get_command_keyboard_binding(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1405,8 +1355,7 @@ int LuaContext::game_api_get_command_keyboard_binding(lua_State* l) {
       push_string(l, key_name);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1416,7 +1365,7 @@ int LuaContext::game_api_get_command_keyboard_binding(lua_State* l) {
  */
 int LuaContext::game_api_set_command_keyboard_binding(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1434,8 +1383,7 @@ int LuaContext::game_api_set_command_keyboard_binding(lua_State* l) {
     commands.set_keyboard_binding(command, key);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1445,7 +1393,7 @@ int LuaContext::game_api_set_command_keyboard_binding(lua_State* l) {
  */
 int LuaContext::game_api_get_command_joypad_binding(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1460,8 +1408,7 @@ int LuaContext::game_api_get_command_joypad_binding(lua_State* l) {
       push_string(l, joypad_string);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1471,7 +1418,7 @@ int LuaContext::game_api_get_command_joypad_binding(lua_State* l) {
  */
 int LuaContext::game_api_set_command_joypad_binding(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1488,8 +1435,7 @@ int LuaContext::game_api_set_command_joypad_binding(lua_State* l) {
     commands.set_joypad_binding(command, joypad_string);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1499,7 +1445,7 @@ int LuaContext::game_api_set_command_joypad_binding(lua_State* l) {
  */
 int LuaContext::game_api_capture_command_binding(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1509,8 +1455,7 @@ int LuaContext::game_api_capture_command_binding(lua_State* l) {
     commands.customize(command, callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1520,7 +1465,7 @@ int LuaContext::game_api_capture_command_binding(lua_State* l) {
  */
 int LuaContext::game_api_is_command_pressed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1529,8 +1474,7 @@ int LuaContext::game_api_is_command_pressed(lua_State* l) {
     lua_pushboolean(l, commands.is_command_pressed(command));
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1540,7 +1484,7 @@ int LuaContext::game_api_is_command_pressed(lua_State* l) {
  */
 int LuaContext::game_api_get_commands_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
 
     GameCommands& commands = savegame.get_game()->get_commands();
@@ -1553,8 +1497,7 @@ int LuaContext::game_api_get_commands_direction(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1564,7 +1507,7 @@ int LuaContext::game_api_get_commands_direction(lua_State* l) {
  */
 int LuaContext::game_api_simulate_command_pressed(lua_State* l){
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1572,8 +1515,7 @@ int LuaContext::game_api_simulate_command_pressed(lua_State* l){
     savegame.get_game()->simulate_command_pressed(command);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1583,7 +1525,7 @@ int LuaContext::game_api_simulate_command_pressed(lua_State* l){
  */
 int LuaContext::game_api_simulate_command_released(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Savegame& savegame = *check_game(l, 1);
     GameCommands::Command command = LuaTools::check_enum<GameCommands::Command>(
         l, 2, GameCommands::command_names);
@@ -1591,8 +1533,7 @@ int LuaContext::game_api_simulate_command_released(lua_State* l) {
     savegame.get_game()->simulate_command_released(command);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/InputApi.cpp
+++ b/src/lua/InputApi.cpp
@@ -54,11 +54,10 @@ void LuaContext::register_input_module() {
  */
 int LuaContext::input_api_is_joypad_enabled(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     lua_pushboolean(l, InputEvent::is_joypad_enabled());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -68,7 +67,7 @@ int LuaContext::input_api_is_joypad_enabled(lua_State* l) {
  */
 int LuaContext::input_api_set_joypad_enabled(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     bool joypad_enabled = true;
     if (lua_gettop(l) >= 2) {
       joypad_enabled = lua_toboolean(l, 2);
@@ -77,8 +76,7 @@ int LuaContext::input_api_set_joypad_enabled(lua_State* l) {
     InputEvent::set_joypad_enabled(joypad_enabled);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -88,7 +86,7 @@ int LuaContext::input_api_set_joypad_enabled(lua_State* l) {
  */
 int LuaContext::input_api_is_key_pressed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& key_name = LuaTools::check_string(l, 1);
     InputEvent::KeyboardKey key = InputEvent::get_keyboard_key_by_name(key_name);
 
@@ -99,8 +97,7 @@ int LuaContext::input_api_is_key_pressed(lua_State* l) {
 
     lua_pushboolean(l, InputEvent::is_key_down(key));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -110,7 +107,7 @@ int LuaContext::input_api_is_key_pressed(lua_State* l) {
  */
 int LuaContext::input_api_get_key_modifiers(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const bool shift = InputEvent::is_shift_down();
     const bool control = InputEvent::is_control_down();
     const bool alt = InputEvent::is_alt_down();
@@ -140,8 +137,7 @@ int LuaContext::input_api_get_key_modifiers(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -151,13 +147,12 @@ int LuaContext::input_api_get_key_modifiers(lua_State* l) {
  */
 int LuaContext::input_api_is_joypad_button_pressed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int button = LuaTools::check_int(l, 1);
 
     lua_pushboolean(l, InputEvent::is_joypad_button_down(button));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -167,13 +162,12 @@ int LuaContext::input_api_is_joypad_button_pressed(lua_State* l) {
  */
 int LuaContext::input_api_get_joypad_axis_state(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int axis = LuaTools::check_int(l, 1);
 
     lua_pushinteger(l, InputEvent::get_joypad_axis_state(axis));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -183,13 +177,12 @@ int LuaContext::input_api_get_joypad_axis_state(lua_State* l) {
  */
 int LuaContext::input_api_get_joypad_hat_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int hat = LuaTools::check_int(l, 1);
 
     lua_pushinteger(l, InputEvent::get_joypad_hat_direction(hat));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -199,7 +192,7 @@ int LuaContext::input_api_get_joypad_hat_direction(lua_State* l) {
  */
 int LuaContext::input_api_is_mouse_button_pressed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& button_name = LuaTools::check_string(l, 1);
     InputEvent::MouseButton button = InputEvent::get_mouse_button_by_name(button_name);
 
@@ -210,8 +203,7 @@ int LuaContext::input_api_is_mouse_button_pressed(lua_State* l) {
 
     lua_pushboolean(l, InputEvent::is_mouse_button_down(button));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -221,7 +213,7 @@ int LuaContext::input_api_is_mouse_button_pressed(lua_State* l) {
  */
 int LuaContext::input_api_is_mouse_button_released(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& button_name = LuaTools::check_string(l, 1);
     InputEvent::MouseButton button = InputEvent::get_mouse_button_by_name(button_name);
 
@@ -232,8 +224,7 @@ int LuaContext::input_api_is_mouse_button_released(lua_State* l) {
 
     lua_pushboolean(l, !InputEvent::is_mouse_button_down(button));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -243,7 +234,7 @@ int LuaContext::input_api_is_mouse_button_released(lua_State* l) {
  */
 int LuaContext::input_api_get_mouse_position(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Rectangle& position = InputEvent::get_global_mouse_position();
 
     if (!position.is_flat()) {
@@ -256,8 +247,7 @@ int LuaContext::input_api_get_mouse_position(lua_State* l) {
     }
 
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lua/ItemApi.cpp
+++ b/src/lua/ItemApi.cpp
@@ -126,13 +126,12 @@ void LuaContext::push_item(lua_State* l, EquipmentItem& item) {
  */
 int LuaContext::item_api_get_name(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     push_string(l, item.get_name());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -142,13 +141,12 @@ int LuaContext::item_api_get_name(lua_State* l) {
  */
 int LuaContext::item_api_get_game(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     push_game(l, item.get_savegame());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -158,7 +156,7 @@ int LuaContext::item_api_get_game(lua_State* l) {
  */
 int LuaContext::item_api_get_map(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     Game* game = item.get_game();
@@ -169,8 +167,7 @@ int LuaContext::item_api_get_map(lua_State* l) {
       lua_pushnil(l);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -180,7 +177,7 @@ int LuaContext::item_api_get_map(lua_State* l) {
  */
 int LuaContext::item_api_get_savegame_variable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     const std::string& savegame_variable = item.get_savegame_variable();
@@ -191,8 +188,7 @@ int LuaContext::item_api_get_savegame_variable(lua_State* l) {
       push_string(l, savegame_variable);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -202,7 +198,7 @@ int LuaContext::item_api_get_savegame_variable(lua_State* l) {
  */
 int LuaContext::item_api_set_savegame_variable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     std::string savegame_variable;
     if (!lua_isnil(l, 2)) {
@@ -219,8 +215,7 @@ int LuaContext::item_api_set_savegame_variable(lua_State* l) {
     item.set_savegame_variable(savegame_variable);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -230,7 +225,7 @@ int LuaContext::item_api_set_savegame_variable(lua_State* l) {
  */
 int LuaContext::item_api_get_amount_savegame_variable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     const std::string& amount_savegame_variable = item.get_amount_savegame_variable();
@@ -241,8 +236,7 @@ int LuaContext::item_api_get_amount_savegame_variable(lua_State* l) {
       push_string(l, amount_savegame_variable);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -252,7 +246,7 @@ int LuaContext::item_api_get_amount_savegame_variable(lua_State* l) {
  */
 int LuaContext::item_api_set_amount_savegame_variable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     std::string amount_savegame_variable;
     if (lua_gettop(l) >= 2) {
@@ -269,8 +263,7 @@ int LuaContext::item_api_set_amount_savegame_variable(lua_State* l) {
     item.set_amount_savegame_variable(amount_savegame_variable);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -280,13 +273,12 @@ int LuaContext::item_api_set_amount_savegame_variable(lua_State* l) {
  */
 int LuaContext::item_api_is_obtainable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     lua_pushboolean(l, item.is_obtainable());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -296,7 +288,7 @@ int LuaContext::item_api_is_obtainable(lua_State* l) {
  */
 int LuaContext::item_api_set_obtainable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     bool obtainable = true;
     if (lua_gettop(l) >= 2) {
@@ -306,8 +298,7 @@ int LuaContext::item_api_set_obtainable(lua_State* l) {
     item.set_obtainable(obtainable);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -317,13 +308,12 @@ int LuaContext::item_api_set_obtainable(lua_State* l) {
  */
 int LuaContext::item_api_is_assignable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     lua_pushboolean(l, item.is_assignable());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -333,7 +323,7 @@ int LuaContext::item_api_is_assignable(lua_State* l) {
  */
 int LuaContext::item_api_set_assignable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     bool assignable = true;
     if (lua_gettop(l) >= 2) {
@@ -343,8 +333,7 @@ int LuaContext::item_api_set_assignable(lua_State* l) {
     item.set_assignable(assignable);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -354,13 +343,12 @@ int LuaContext::item_api_set_assignable(lua_State* l) {
  */
 int LuaContext::item_api_get_can_disappear(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     lua_pushboolean(l, item.get_can_disappear());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -370,7 +358,7 @@ int LuaContext::item_api_get_can_disappear(lua_State* l) {
  */
 int LuaContext::item_api_set_can_disappear(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     bool can_disappear = true;
     if (lua_gettop(l) >= 2) {
@@ -380,8 +368,7 @@ int LuaContext::item_api_set_can_disappear(lua_State* l) {
     item.set_can_disappear(can_disappear);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -391,13 +378,12 @@ int LuaContext::item_api_set_can_disappear(lua_State* l) {
  */
 int LuaContext::item_api_get_brandish_when_picked(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     lua_pushboolean(l, item.get_brandish_when_picked());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -407,7 +393,7 @@ int LuaContext::item_api_get_brandish_when_picked(lua_State* l) {
  */
 int LuaContext::item_api_set_brandish_when_picked(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     bool brandish_when_picked = true;
     if (lua_gettop(l) >= 2) {
@@ -417,8 +403,7 @@ int LuaContext::item_api_set_brandish_when_picked(lua_State* l) {
     item.set_brandish_when_picked(brandish_when_picked);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -428,7 +413,7 @@ int LuaContext::item_api_set_brandish_when_picked(lua_State* l) {
  */
 int LuaContext::item_api_get_shadow(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     const std::string& shadow = item.get_shadow();
@@ -439,8 +424,7 @@ int LuaContext::item_api_get_shadow(lua_State* l) {
       push_string(l, shadow);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -450,7 +434,7 @@ int LuaContext::item_api_get_shadow(lua_State* l) {
  */
 int LuaContext::item_api_set_shadow(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     std::string shadow;
     if (!lua_isnil(l, 2)) {
@@ -460,8 +444,7 @@ int LuaContext::item_api_set_shadow(lua_State* l) {
     item.set_shadow(shadow);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -471,7 +454,7 @@ int LuaContext::item_api_set_shadow(lua_State* l) {
  */
 int LuaContext::item_api_get_sound_when_picked(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     const std::string& sound_when_picked = item.get_sound_when_picked();
@@ -482,8 +465,7 @@ int LuaContext::item_api_get_sound_when_picked(lua_State* l) {
       push_string(l, sound_when_picked);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -493,7 +475,7 @@ int LuaContext::item_api_get_sound_when_picked(lua_State* l) {
  */
 int LuaContext::item_api_set_sound_when_picked(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     std::string sound_when_picked;
     if (!lua_isnil(l, 2)) {
@@ -503,8 +485,7 @@ int LuaContext::item_api_set_sound_when_picked(lua_State* l) {
     item.set_sound_when_picked(sound_when_picked);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -514,7 +495,7 @@ int LuaContext::item_api_set_sound_when_picked(lua_State* l) {
  */
 int LuaContext::item_api_get_sound_when_brandished(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     const std::string& sound_when_brandished = item.get_sound_when_brandished();
@@ -525,8 +506,7 @@ int LuaContext::item_api_get_sound_when_brandished(lua_State* l) {
       push_string(l, sound_when_brandished);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -536,7 +516,7 @@ int LuaContext::item_api_get_sound_when_brandished(lua_State* l) {
  */
 int LuaContext::item_api_set_sound_when_brandished(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     std::string sound_when_brandished;
     if (!lua_isnil(l, 2)) {
@@ -546,8 +526,7 @@ int LuaContext::item_api_set_sound_when_brandished(lua_State* l) {
     item.set_sound_when_brandished(sound_when_brandished);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -557,7 +536,7 @@ int LuaContext::item_api_set_sound_when_brandished(lua_State* l) {
  */
 int LuaContext::item_api_has_variant(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     int variant = 1;
     if (lua_gettop(l) >= 2) {
@@ -566,8 +545,7 @@ int LuaContext::item_api_has_variant(lua_State* l) {
 
     lua_pushboolean(l, item.get_variant() >= variant);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -577,7 +555,7 @@ int LuaContext::item_api_has_variant(lua_State* l) {
  */
 int LuaContext::item_api_get_variant(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     if (!item.is_saved()) {
@@ -586,8 +564,7 @@ int LuaContext::item_api_get_variant(lua_State* l) {
 
     lua_pushinteger(l, item.get_variant());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -597,7 +574,7 @@ int LuaContext::item_api_get_variant(lua_State* l) {
  */
 int LuaContext::item_api_set_variant(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     int variant = LuaTools::check_int(l, 2);
 
@@ -608,8 +585,7 @@ int LuaContext::item_api_set_variant(lua_State* l) {
     item.set_variant(variant);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -619,7 +595,7 @@ int LuaContext::item_api_set_variant(lua_State* l) {
  */
 int LuaContext::item_api_has_amount(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     if (lua_gettop(l) >= 2) {
       int amount = LuaTools::check_int(l, 2);
@@ -632,8 +608,7 @@ int LuaContext::item_api_has_amount(lua_State* l) {
       lua_pushboolean(l, item.has_amount());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -643,7 +618,7 @@ int LuaContext::item_api_has_amount(lua_State* l) {
  */
 int LuaContext::item_api_get_amount(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     if (!item.has_amount()) {
@@ -653,8 +628,7 @@ int LuaContext::item_api_get_amount(lua_State* l) {
       lua_pushinteger(l, item.get_amount());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -664,7 +638,7 @@ int LuaContext::item_api_get_amount(lua_State* l) {
  */
 int LuaContext::item_api_set_amount(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     int amount = LuaTools::check_int(l, 2);
 
@@ -675,8 +649,7 @@ int LuaContext::item_api_set_amount(lua_State* l) {
     item.set_amount(amount);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -686,7 +659,7 @@ int LuaContext::item_api_set_amount(lua_State* l) {
  */
 int LuaContext::item_api_add_amount(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     int amount = LuaTools::check_int(l, 2);
 
@@ -701,8 +674,7 @@ int LuaContext::item_api_add_amount(lua_State* l) {
     item.set_amount(item.get_amount() + amount);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -712,7 +684,7 @@ int LuaContext::item_api_add_amount(lua_State* l) {
  */
 int LuaContext::item_api_remove_amount(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     int amount = LuaTools::check_int(l, 2);
 
@@ -727,8 +699,7 @@ int LuaContext::item_api_remove_amount(lua_State* l) {
     item.set_amount(item.get_amount() - amount);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -738,7 +709,7 @@ int LuaContext::item_api_remove_amount(lua_State* l) {
  */
 int LuaContext::item_api_get_max_amount(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     if (!item.has_amount()) {
@@ -747,8 +718,7 @@ int LuaContext::item_api_get_max_amount(lua_State* l) {
 
     lua_pushinteger(l, item.get_max_amount());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -758,7 +728,7 @@ int LuaContext::item_api_get_max_amount(lua_State* l) {
  */
 int LuaContext::item_api_set_max_amount(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
     int max_amount = LuaTools::check_int(l, 2);
 
@@ -773,8 +743,7 @@ int LuaContext::item_api_set_max_amount(lua_State* l) {
     item.set_max_amount(max_amount);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -784,7 +753,7 @@ int LuaContext::item_api_set_max_amount(lua_State* l) {
  */
 int LuaContext::item_api_set_finished(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     EquipmentItem& item = check_item(l, 1);
 
     // Retrieve the equipment item from the hero.
@@ -796,8 +765,7 @@ int LuaContext::item_api_set_finished(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/LanguageApi.cpp
+++ b/src/lua/LanguageApi.cpp
@@ -81,7 +81,7 @@ void LuaContext::register_language_module() {
  */
 int LuaContext::language_api_get_language(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& language = Language::get_language();
 
     if (language.empty()) {  // Return nil if no language is set.
@@ -91,8 +91,7 @@ int LuaContext::language_api_get_language(lua_State* l) {
       push_string(l, language);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -102,7 +101,7 @@ int LuaContext::language_api_get_language(lua_State* l) {
  */
 int LuaContext::language_api_set_language(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& language_code = LuaTools::check_string(l, 1);
 
     if (!Language::has_language(language_code)) {
@@ -111,8 +110,7 @@ int LuaContext::language_api_set_language(lua_State* l) {
     Language::set_language(language_code);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -122,7 +120,7 @@ int LuaContext::language_api_set_language(lua_State* l) {
  */
 int LuaContext::language_api_get_language_name(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::string language_code;
     if (lua_gettop(l) >= 1) {
       language_code = LuaTools::check_string(l, 1);
@@ -141,8 +139,7 @@ int LuaContext::language_api_get_language_name(lua_State* l) {
     push_string(l, name);
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -152,7 +149,7 @@ int LuaContext::language_api_get_language_name(lua_State* l) {
  */
 int LuaContext::language_api_get_languages(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::vector<QuestResourceList::Element>& languages =
         QuestResourceList::get_elements(QuestResourceList::RESOURCE_LANGUAGE);
 
@@ -166,8 +163,7 @@ int LuaContext::language_api_get_languages(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -177,7 +173,7 @@ int LuaContext::language_api_get_languages(lua_State* l) {
  */
 int LuaContext::language_api_get_string(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& key = LuaTools::check_string(l, 1);
 
     if (!StringResource::exists(key)) {
@@ -187,8 +183,7 @@ int LuaContext::language_api_get_string(lua_State* l) {
       push_string(l, StringResource::get_string(key));
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -198,7 +193,7 @@ int LuaContext::language_api_get_string(lua_State* l) {
  */
 int LuaContext::language_api_get_dialog(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& dialog_id = LuaTools::check_string(l, 1);
 
     if (!DialogResource::exists(dialog_id)) {
@@ -208,8 +203,7 @@ int LuaContext::language_api_get_dialog(lua_State* l) {
       push_dialog(l, DialogResource::get_dialog(dialog_id));
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lua/LuaContext.cpp
+++ b/src/lua/LuaContext.cpp
@@ -2688,7 +2688,7 @@ int LuaContext::l_panic(lua_State* l) {
  */
 int LuaContext::l_loader(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& script_name = luaL_checkstring(l, 1);
     bool exists = load_file_if_exists(l, script_name);
 
@@ -2699,8 +2699,7 @@ int LuaContext::l_loader(lua_State* l) {
       push_string(l, oss.str());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lua/MainApi.cpp
+++ b/src/lua/MainApi.cpp
@@ -88,7 +88,7 @@ void LuaContext::push_main(lua_State* l) {
  */
 int LuaContext::main_api_load_file(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& file_name = LuaTools::check_string(l, 1);
 
     if (!load_file_if_exists(l, file_name)) {
@@ -96,8 +96,7 @@ int LuaContext::main_api_load_file(lua_State *l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -107,14 +106,13 @@ int LuaContext::main_api_load_file(lua_State *l) {
  */
 int LuaContext::main_api_do_file(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& file_name = LuaTools::check_string(l, 1);
 
     do_file(l, file_name);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -124,12 +122,11 @@ int LuaContext::main_api_do_file(lua_State *l) {
  */
 int LuaContext::main_api_reset(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     get_lua_context(l).get_main_loop().set_resetting();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -139,12 +136,11 @@ int LuaContext::main_api_reset(lua_State* l) {
  */
 int LuaContext::main_api_exit(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     get_lua_context(l).get_main_loop().set_exiting();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -154,13 +150,12 @@ int LuaContext::main_api_exit(lua_State* l) {
  */
 int LuaContext::main_api_get_elapsed_time(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     uint32_t elapsed_time = System::now();
 
     lua_pushinteger(l, elapsed_time);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -170,7 +165,7 @@ int LuaContext::main_api_get_elapsed_time(lua_State* l) {
  */
 int LuaContext::main_api_get_quest_write_dir(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& quest_write_dir = FileTools::get_quest_write_dir();
 
     if (quest_write_dir.empty()) {
@@ -180,8 +175,7 @@ int LuaContext::main_api_get_quest_write_dir(lua_State* l) {
       push_string(l, quest_write_dir);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -191,14 +185,13 @@ int LuaContext::main_api_get_quest_write_dir(lua_State* l) {
  */
 int LuaContext::main_api_set_quest_write_dir(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& quest_write_dir = LuaTools::opt_string(l, 1, "");
 
     FileTools::set_quest_write_dir(quest_write_dir);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -208,7 +201,7 @@ int LuaContext::main_api_set_quest_write_dir(lua_State* l) {
  */
 int LuaContext::main_api_load_settings(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::string file_name = LuaTools::opt_string(l, 1, "settings.dat");
 
     if (FileTools::get_quest_write_dir().empty()) {
@@ -219,8 +212,7 @@ int LuaContext::main_api_load_settings(lua_State* l) {
 
     lua_pushboolean(l, success);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -230,7 +222,7 @@ int LuaContext::main_api_load_settings(lua_State* l) {
  */
 int LuaContext::main_api_save_settings(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::string file_name = LuaTools::opt_string(l, 1, "settings.dat");
 
     if (FileTools::get_quest_write_dir().empty()) {
@@ -241,8 +233,7 @@ int LuaContext::main_api_save_settings(lua_State* l) {
 
     lua_pushboolean(l, success);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -252,7 +243,7 @@ int LuaContext::main_api_save_settings(lua_State* l) {
  */
 int LuaContext::main_api_get_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int x1 = LuaTools::check_int(l, 1);
     int y1 = LuaTools::check_int(l, 2);
     int x2 = LuaTools::check_int(l, 3);
@@ -262,8 +253,7 @@ int LuaContext::main_api_get_distance(lua_State* l) {
 
     lua_pushinteger(l, distance);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -273,7 +263,7 @@ int LuaContext::main_api_get_distance(lua_State* l) {
  */
 int LuaContext::main_api_get_angle(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int x1 = LuaTools::check_int(l, 1);
     int y1 = LuaTools::check_int(l, 2);
     int x2 = LuaTools::check_int(l, 3);
@@ -283,8 +273,7 @@ int LuaContext::main_api_get_angle(lua_State* l) {
 
     lua_pushnumber(l, angle);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -294,13 +283,12 @@ int LuaContext::main_api_get_angle(lua_State* l) {
  */
 int LuaContext::main_api_get_metatable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& type_name = LuaTools::check_string(l, 1);
 
     luaL_getmetatable(l, (std::string("sol.") + type_name).c_str());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/MapApi.cpp
+++ b/src/lua/MapApi.cpp
@@ -278,7 +278,7 @@ void LuaContext::set_entity_implicit_creation_map(lua_State* l, Map* map) {
  */
 int LuaContext::l_get_map_entity_or_global(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     lua_pushvalue(l, lua_upvalueindex(1));  // Because check_map does not like pseudo-indexes.
     Map& map = check_map(l, -1);
     const std::string& name = LuaTools::check_string(l, 2);
@@ -295,8 +295,7 @@ int LuaContext::l_get_map_entity_or_global(lua_State* l) {
       lua_getglobal(l, name.c_str());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -306,7 +305,7 @@ int LuaContext::l_get_map_entity_or_global(lua_State* l) {
  */
 int LuaContext::l_camera_do_callback(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     // Execute the function.
     lua_settop(l, 0);
     lua_getfield(l, LUA_REGISTRYINDEX, "sol.camera_function");
@@ -322,8 +321,7 @@ int LuaContext::l_camera_do_callback(lua_State* l) {
     timer->set_suspended_with_map(false);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -333,14 +331,13 @@ int LuaContext::l_camera_do_callback(lua_State* l) {
  */
 int LuaContext::l_camera_restore(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     lua_context.get_main_loop().get_game()->get_current_map().restore_camera();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -350,13 +347,12 @@ int LuaContext::l_camera_restore(lua_State* l) {
  */
 int LuaContext::map_api_get_game(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     push_game(l, map.get_game().get_savegame());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -366,13 +362,12 @@ int LuaContext::map_api_get_game(lua_State* l) {
  */
 int LuaContext::map_api_get_id(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     push_string(l, map.get_id());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -382,7 +377,7 @@ int LuaContext::map_api_get_id(lua_State* l) {
  */
 int LuaContext::map_api_get_world(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     const std::string& world = map.get_world();
@@ -394,8 +389,7 @@ int LuaContext::map_api_get_world(lua_State* l) {
       push_string(l, world);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -405,7 +399,7 @@ int LuaContext::map_api_get_world(lua_State* l) {
  */
 int LuaContext::map_api_get_floor(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     if (!map.has_floor()) {
@@ -415,8 +409,7 @@ int LuaContext::map_api_get_floor(lua_State* l) {
       lua_pushinteger(l, map.get_floor());
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -426,15 +419,14 @@ int LuaContext::map_api_get_floor(lua_State* l) {
  */
 int LuaContext::map_api_get_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     lua_pushinteger(l, map.get_width());
     lua_pushinteger(l, map.get_height());
 
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -444,15 +436,14 @@ int LuaContext::map_api_get_size(lua_State* l) {
  */
 int LuaContext::map_api_get_location(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     lua_pushinteger(l, map.get_location().get_x());
     lua_pushinteger(l, map.get_location().get_y());
 
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -462,13 +453,12 @@ int LuaContext::map_api_get_location(lua_State* l) {
  */
 int LuaContext::map_api_get_tileset(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     push_string(l, map.get_tileset_id());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -478,7 +468,7 @@ int LuaContext::map_api_get_tileset(lua_State* l) {
  */
 int LuaContext::map_api_get_music(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     const std::string& music_id = map.get_music_id();
@@ -494,8 +484,7 @@ int LuaContext::map_api_get_music(lua_State* l) {
       push_string(l, music_id);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -505,15 +494,14 @@ int LuaContext::map_api_get_music(lua_State* l) {
  */
 int LuaContext::map_api_set_tileset(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& tileset_id = LuaTools::check_string(l, 2);
 
     map.set_tileset(tileset_id);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -523,7 +511,7 @@ int LuaContext::map_api_set_tileset(lua_State* l) {
  */
 int LuaContext::map_api_get_camera_position(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     const Rectangle& camera_position = map.get_camera_position();
@@ -533,8 +521,7 @@ int LuaContext::map_api_get_camera_position(lua_State* l) {
     lua_pushinteger(l, camera_position.get_width());
     lua_pushinteger(l, camera_position.get_height());
     return 4;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -544,7 +531,7 @@ int LuaContext::map_api_get_camera_position(lua_State* l) {
  */
 int LuaContext::map_api_move_camera(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     int x = LuaTools::check_int(l, 2);
     int y = LuaTools::check_int(l, 3);
@@ -573,8 +560,7 @@ int LuaContext::map_api_move_camera(lua_State* l) {
     map.move_camera(x, y, speed);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -584,7 +570,7 @@ int LuaContext::map_api_move_camera(lua_State* l) {
  */
 int LuaContext::map_api_get_ground(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     int x = LuaTools::check_int(l, 2);
     int y = LuaTools::check_int(l, 3);
@@ -594,8 +580,7 @@ int LuaContext::map_api_get_ground(lua_State* l) {
 
     push_string(l, Tileset::ground_names[ground]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -605,7 +590,7 @@ int LuaContext::map_api_get_ground(lua_State* l) {
  */
 int LuaContext::map_api_draw_sprite(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     Sprite& sprite = *check_sprite(l, 2);
     int x = LuaTools::check_int(l, 3);
@@ -614,8 +599,7 @@ int LuaContext::map_api_draw_sprite(lua_State* l) {
     map.draw_sprite(sprite, x, y);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -625,13 +609,12 @@ int LuaContext::map_api_draw_sprite(lua_State* l) {
  */
 int LuaContext::map_api_get_crystal_state(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     lua_pushboolean(l, map.get_game().get_crystal_state());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -641,7 +624,7 @@ int LuaContext::map_api_get_crystal_state(lua_State* l) {
  */
 int LuaContext::map_api_set_crystal_state(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     bool state = lua_toboolean(l, 2);
 
@@ -651,8 +634,7 @@ int LuaContext::map_api_set_crystal_state(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -662,14 +644,13 @@ int LuaContext::map_api_set_crystal_state(lua_State* l) {
  */
 int LuaContext::map_api_change_crystal_state(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     map.get_game().change_crystal_state();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -679,7 +660,7 @@ int LuaContext::map_api_change_crystal_state(lua_State* l) {
  */
 int LuaContext::map_api_open_doors(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& prefix = LuaTools::check_string(l, 2);
 
@@ -701,8 +682,7 @@ int LuaContext::map_api_open_doors(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -712,7 +692,7 @@ int LuaContext::map_api_open_doors(lua_State* l) {
  */
 int LuaContext::map_api_close_doors(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& prefix = LuaTools::check_string(l, 2);
 
@@ -734,8 +714,7 @@ int LuaContext::map_api_close_doors(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -745,7 +724,7 @@ int LuaContext::map_api_close_doors(lua_State* l) {
  */
 int LuaContext::map_api_set_doors_open(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& prefix = LuaTools::check_string(l, 2);
     bool open = true;
@@ -761,8 +740,7 @@ int LuaContext::map_api_set_doors_open(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -772,7 +750,7 @@ int LuaContext::map_api_set_doors_open(lua_State* l) {
  */
 int LuaContext::map_api_get_entity(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& name = LuaTools::check_string(l, 2);
 
@@ -785,8 +763,7 @@ int LuaContext::map_api_get_entity(lua_State* l) {
       lua_pushnil(l);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -796,7 +773,7 @@ int LuaContext::map_api_get_entity(lua_State* l) {
  */
 int LuaContext::map_api_has_entity(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& name = LuaTools::check_string(l, 2);
 
@@ -804,8 +781,7 @@ int LuaContext::map_api_has_entity(lua_State* l) {
 
     lua_pushboolean(l, entity != nullptr);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -815,7 +791,7 @@ int LuaContext::map_api_has_entity(lua_State* l) {
  */
 int LuaContext::map_api_get_entities(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& prefix = LuaTools::check_string(l, 2);
 
@@ -837,8 +813,7 @@ int LuaContext::map_api_get_entities(lua_State* l) {
     // with io.open) to be sure it is the original one.
 
     return 3;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -848,7 +823,7 @@ int LuaContext::map_api_get_entities(lua_State* l) {
  */
 int LuaContext::map_api_get_entities_count(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& prefix = LuaTools::check_string(l, 2);
 
@@ -857,8 +832,7 @@ int LuaContext::map_api_get_entities_count(lua_State* l) {
 
     lua_pushinteger(l, entities.size());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -868,14 +842,13 @@ int LuaContext::map_api_get_entities_count(lua_State* l) {
  */
 int LuaContext::map_api_has_entities(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& prefix = LuaTools::check_string(l, 2);
 
     lua_pushboolean(l, map.get_entities().has_entity_with_prefix(prefix));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -885,14 +858,13 @@ int LuaContext::map_api_has_entities(lua_State* l) {
  */
 int LuaContext::map_api_get_hero(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
 
     // Return the hero even if he is no longer on this map.
     push_hero(l, *map.get_game().get_hero());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -902,7 +874,7 @@ int LuaContext::map_api_get_hero(lua_State* l) {
  */
 int LuaContext::map_api_set_entities_enabled(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& prefix = LuaTools::check_string(l, 2);
     bool enabled = true;
@@ -917,8 +889,7 @@ int LuaContext::map_api_set_entities_enabled(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -928,14 +899,13 @@ int LuaContext::map_api_set_entities_enabled(lua_State* l) {
  */
 int LuaContext::map_api_remove_entities(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = check_map(l, 1);
     const std::string& prefix = LuaTools::check_string(l, 2);
 
     map.get_entities().remove_entities_with_prefix(prefix);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 namespace {
@@ -978,7 +948,7 @@ void entity_creation_check_size(
  */
 int LuaContext::map_api_create_tile(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
 
     // Should not happen: create_tile is not in the map metatable.
@@ -1012,8 +982,7 @@ int LuaContext::map_api_create_tile(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1023,7 +992,7 @@ int LuaContext::map_api_create_tile(lua_State* l) {
  */
 int LuaContext::map_api_create_destination(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1049,8 +1018,7 @@ int LuaContext::map_api_create_destination(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1060,7 +1028,7 @@ int LuaContext::map_api_create_destination(lua_State* l) {
  */
 int LuaContext::map_api_create_teletransporter(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1097,8 +1065,7 @@ int LuaContext::map_api_create_teletransporter(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1108,7 +1075,7 @@ int LuaContext::map_api_create_teletransporter(lua_State* l) {
  */
 int LuaContext::map_api_create_pickable(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1157,8 +1124,7 @@ int LuaContext::map_api_create_pickable(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1168,7 +1134,7 @@ int LuaContext::map_api_create_pickable(lua_State* l) {
  */
 int LuaContext::map_api_create_destructible(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1222,8 +1188,7 @@ int LuaContext::map_api_create_destructible(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1233,7 +1198,7 @@ int LuaContext::map_api_create_destructible(lua_State* l) {
  */
 int LuaContext::map_api_create_chest(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1303,8 +1268,7 @@ int LuaContext::map_api_create_chest(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1314,7 +1278,7 @@ int LuaContext::map_api_create_chest(lua_State* l) {
  */
 int LuaContext::map_api_create_jumper(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1344,8 +1308,7 @@ int LuaContext::map_api_create_jumper(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1355,7 +1318,7 @@ int LuaContext::map_api_create_jumper(lua_State* l) {
  */
 int LuaContext::map_api_create_enemy(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1411,8 +1374,7 @@ int LuaContext::map_api_create_enemy(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1422,7 +1384,7 @@ int LuaContext::map_api_create_enemy(lua_State* l) {
  */
 int LuaContext::map_api_create_npc(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1456,8 +1418,7 @@ int LuaContext::map_api_create_npc(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1467,7 +1428,7 @@ int LuaContext::map_api_create_npc(lua_State* l) {
  */
 int LuaContext::map_api_create_block(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1503,8 +1464,7 @@ int LuaContext::map_api_create_block(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1514,7 +1474,7 @@ int LuaContext::map_api_create_block(lua_State* l) {
  */
 int LuaContext::map_api_create_dynamic_tile(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1545,8 +1505,7 @@ int LuaContext::map_api_create_dynamic_tile(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1556,7 +1515,7 @@ int LuaContext::map_api_create_dynamic_tile(lua_State* l) {
  */
 int LuaContext::map_api_create_switch(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1588,8 +1547,7 @@ int LuaContext::map_api_create_switch(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1599,7 +1557,7 @@ int LuaContext::map_api_create_switch(lua_State* l) {
  */
 int LuaContext::map_api_create_wall(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1636,8 +1594,7 @@ int LuaContext::map_api_create_wall(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1647,7 +1604,7 @@ int LuaContext::map_api_create_wall(lua_State* l) {
  */
 int LuaContext::map_api_create_sensor(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1673,8 +1630,7 @@ int LuaContext::map_api_create_sensor(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1684,7 +1640,7 @@ int LuaContext::map_api_create_sensor(lua_State* l) {
  */
 int LuaContext::map_api_create_crystal(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1704,8 +1660,7 @@ int LuaContext::map_api_create_crystal(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1715,7 +1670,7 @@ int LuaContext::map_api_create_crystal(lua_State* l) {
  */
 int LuaContext::map_api_create_crystal_block(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1749,8 +1704,7 @@ int LuaContext::map_api_create_crystal_block(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1760,7 +1714,7 @@ int LuaContext::map_api_create_crystal_block(lua_State* l) {
  */
 int LuaContext::map_api_create_shop_treasure(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1803,8 +1757,7 @@ int LuaContext::map_api_create_shop_treasure(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1814,7 +1767,7 @@ int LuaContext::map_api_create_shop_treasure(lua_State* l) {
  */
 int LuaContext::map_api_create_stream(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1847,8 +1800,7 @@ int LuaContext::map_api_create_stream(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1858,7 +1810,7 @@ int LuaContext::map_api_create_stream(lua_State* l) {
  */
 int LuaContext::map_api_create_door(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1921,8 +1873,7 @@ int LuaContext::map_api_create_door(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1932,7 +1883,7 @@ int LuaContext::map_api_create_door(lua_State* l) {
  */
 int LuaContext::map_api_create_stairs(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1960,8 +1911,7 @@ int LuaContext::map_api_create_stairs(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1971,7 +1921,7 @@ int LuaContext::map_api_create_stairs(lua_State* l) {
  */
 int LuaContext::map_api_create_separator(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -1998,8 +1948,7 @@ int LuaContext::map_api_create_separator(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2009,7 +1958,7 @@ int LuaContext::map_api_create_separator(lua_State* l) {
  */
 int LuaContext::map_api_create_custom_entity(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -2044,8 +1993,7 @@ int LuaContext::map_api_create_custom_entity(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2055,7 +2003,7 @@ int LuaContext::map_api_create_custom_entity(lua_State* l) {
  */
 int LuaContext::map_api_create_bomb(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -2075,8 +2023,7 @@ int LuaContext::map_api_create_bomb(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2086,7 +2033,7 @@ int LuaContext::map_api_create_bomb(lua_State* l) {
  */
 int LuaContext::map_api_create_explosion(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -2106,8 +2053,7 @@ int LuaContext::map_api_create_explosion(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -2117,7 +2063,7 @@ int LuaContext::map_api_create_explosion(lua_State* l) {
  */
 int LuaContext::map_api_create_fire(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Map& map = get_entity_creation_map(l);
     LuaTools::check_type(l, 1, LUA_TTABLE);
     const std::string& name = LuaTools::opt_string_field(l, 1, "name", "");
@@ -2136,8 +2082,7 @@ int LuaContext::map_api_create_fire(lua_State* l) {
       return 1;
     }
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/MenuApi.cpp
+++ b/src/lua/MenuApi.cpp
@@ -177,7 +177,7 @@ void LuaContext::update_menus() {
  */
 int LuaContext::menu_api_start(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     // Parameters: context table.
     if (lua_type(l, 1) != LUA_TTABLE
         && lua_type(l, 1) != LUA_TUSERDATA) {
@@ -195,8 +195,7 @@ int LuaContext::menu_api_start(lua_State *l) {
     lua_context.add_menu(menu_ref, 1, on_top);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -206,7 +205,7 @@ int LuaContext::menu_api_start(lua_State *l) {
  */
 int LuaContext::menu_api_stop(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     LuaTools::check_type(l, 1, LUA_TTABLE);
@@ -226,8 +225,7 @@ int LuaContext::menu_api_stop(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -237,7 +235,7 @@ int LuaContext::menu_api_stop(lua_State* l) {
  */
 int LuaContext::menu_api_stop_all(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     if (lua_type(l, 1) != LUA_TTABLE
         && lua_type(l, 1) != LUA_TUSERDATA) {
       LuaTools::type_error(l, 1, "table, game or map");
@@ -246,8 +244,7 @@ int LuaContext::menu_api_stop_all(lua_State* l) {
     get_lua_context(l).remove_menus(1);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -257,7 +254,7 @@ int LuaContext::menu_api_stop_all(lua_State* l) {
  */
 int LuaContext::menu_api_is_started(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     LuaTools::check_type(l, 1, LUA_TTABLE);
@@ -277,8 +274,7 @@ int LuaContext::menu_api_is_started(lua_State* l) {
     lua_pushboolean(l, found);
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/MovementApi.cpp
+++ b/src/lua/MovementApi.cpp
@@ -474,7 +474,7 @@ void LuaContext::update_movements() {
  */
 int LuaContext::movement_api_create(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
     const std::string& type = LuaTools::check_string(l, 1);
 
@@ -544,8 +544,7 @@ int LuaContext::movement_api_create(lua_State* l) {
 
     push_movement(l, *movement);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -555,15 +554,14 @@ int LuaContext::movement_api_create(lua_State* l) {
  */
 int LuaContext::movement_api_get_xy(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Movement& movement = *check_movement(l, 1);
 
     const Point& xy = movement.get_xy();
     lua_pushinteger(l, xy.x);
     lua_pushinteger(l, xy.y);
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -573,7 +571,7 @@ int LuaContext::movement_api_get_xy(lua_State* l) {
  */
 int LuaContext::movement_api_set_xy(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Movement& movement = *check_movement(l, 1);
     int x = LuaTools::check_int(l, 2);
     int y = LuaTools::check_int(l, 3);
@@ -581,8 +579,7 @@ int LuaContext::movement_api_set_xy(lua_State* l) {
     movement.set_xy(x, y);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -592,7 +589,7 @@ int LuaContext::movement_api_set_xy(lua_State* l) {
  */
 int LuaContext::movement_api_start(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     std::shared_ptr<Movement> movement = check_movement(l, 1);
@@ -619,8 +616,7 @@ int LuaContext::movement_api_start(lua_State* l) {
     movement->set_finished_callback(callback_ref);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -630,7 +626,7 @@ int LuaContext::movement_api_start(lua_State* l) {
  */
 int LuaContext::movement_api_stop(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     std::shared_ptr<Movement> movement = check_movement(l, 1);
@@ -653,8 +649,7 @@ int LuaContext::movement_api_stop(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -664,13 +659,12 @@ int LuaContext::movement_api_stop(lua_State* l) {
  */
 int LuaContext::movement_api_get_ignore_obstacles(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Movement> movement = check_movement(l, 1);
 
     lua_pushboolean(l, movement->are_obstacles_ignored());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -680,7 +674,7 @@ int LuaContext::movement_api_get_ignore_obstacles(lua_State* l) {
  */
 int LuaContext::movement_api_set_ignore_obstacles(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Movement> movement = check_movement(l, 1);
     bool ignore_obstacles = true; // true if unspecified
     if (lua_gettop(l) >= 2) {
@@ -690,8 +684,7 @@ int LuaContext::movement_api_set_ignore_obstacles(lua_State* l) {
     movement->set_ignore_obstacles(ignore_obstacles);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -701,12 +694,11 @@ int LuaContext::movement_api_set_ignore_obstacles(lua_State* l) {
  */
 int LuaContext::movement_api_get_direction4(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::shared_ptr<Movement> movement = check_movement(l, 1);
     lua_pushinteger(l, movement->get_displayed_direction4());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -740,12 +732,11 @@ StraightMovement& LuaContext::check_straight_movement(lua_State* l, int index) {
  */
 int LuaContext::straight_movement_api_get_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     StraightMovement& movement = check_straight_movement(l, 1);
     lua_pushinteger(l, movement.get_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -768,12 +759,11 @@ int LuaContext::straight_movement_api_set_speed(lua_State* l) {
  */
 int LuaContext::straight_movement_api_get_angle(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     StraightMovement& movement = check_straight_movement(l, 1);
     lua_pushnumber(l, movement.get_angle());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -783,13 +773,12 @@ int LuaContext::straight_movement_api_get_angle(lua_State* l) {
  */
 int LuaContext::straight_movement_api_set_angle(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     StraightMovement& movement = check_straight_movement(l, 1);
     double angle = LuaTools::check_number(l, 2);
     movement.set_angle(angle);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -799,12 +788,11 @@ int LuaContext::straight_movement_api_set_angle(lua_State* l) {
  */
 int LuaContext::straight_movement_api_get_max_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     StraightMovement& movement = check_straight_movement(l, 1);
     lua_pushinteger(l, movement.get_max_distance());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -814,13 +802,12 @@ int LuaContext::straight_movement_api_get_max_distance(lua_State* l) {
  */
 int LuaContext::straight_movement_api_set_max_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     StraightMovement& movement = check_straight_movement(l, 1);
     int max_distance = LuaTools::check_int(l, 2);
     movement.set_max_distance(max_distance);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -830,12 +817,11 @@ int LuaContext::straight_movement_api_set_max_distance(lua_State* l) {
  */
 int LuaContext::straight_movement_api_is_smooth(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     StraightMovement& movement = check_straight_movement(l, 1);
     lua_pushboolean(l, movement.is_smooth());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -845,7 +831,7 @@ int LuaContext::straight_movement_api_is_smooth(lua_State* l) {
  */
 int LuaContext::straight_movement_api_set_smooth(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     StraightMovement& movement = check_straight_movement(l, 1);
     bool smooth = true; // true if unspecified
     if (lua_gettop(l) >= 2) {
@@ -854,8 +840,7 @@ int LuaContext::straight_movement_api_set_smooth(lua_State* l) {
     movement.set_smooth(smooth);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -888,12 +873,11 @@ RandomMovement& LuaContext::check_random_movement(lua_State* l, int index) {
  */
 int LuaContext::random_movement_api_get_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomMovement& movement = check_random_movement(l, 1);
     lua_pushinteger(l, movement.get_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -903,13 +887,12 @@ int LuaContext::random_movement_api_get_speed(lua_State* l) {
  */
 int LuaContext::random_movement_api_set_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomMovement& movement = check_random_movement(l, 1);
     int speed = LuaTools::check_int(l, 2);
     movement.set_normal_speed(speed);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -919,12 +902,11 @@ int LuaContext::random_movement_api_set_speed(lua_State* l) {
  */
 int LuaContext::random_movement_api_get_angle(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomMovement& movement = check_random_movement(l, 1);
     lua_pushnumber(l, movement.get_angle());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -934,12 +916,11 @@ int LuaContext::random_movement_api_get_angle(lua_State* l) {
  */
 int LuaContext::random_movement_api_get_max_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomMovement& movement = check_random_movement(l, 1);
     lua_pushinteger(l, movement.get_max_radius());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -949,13 +930,12 @@ int LuaContext::random_movement_api_get_max_distance(lua_State* l) {
  */
 int LuaContext::random_movement_api_set_max_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomMovement& movement = check_random_movement(l, 1);
     int max_radius = LuaTools::check_int(l, 2);
     movement.set_max_radius(max_radius);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -965,12 +945,11 @@ int LuaContext::random_movement_api_set_max_distance(lua_State* l) {
  */
 int LuaContext::random_movement_api_is_smooth(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomMovement& movement = check_random_movement(l, 1);
     lua_pushboolean(l, movement.is_smooth());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -980,7 +959,7 @@ int LuaContext::random_movement_api_is_smooth(lua_State* l) {
  */
 int LuaContext::random_movement_api_set_smooth(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomMovement& movement = check_random_movement(l, 1);
     bool smooth = true; // true if unspecified
     if (lua_gettop(l) >= 2) {
@@ -989,8 +968,7 @@ int LuaContext::random_movement_api_set_smooth(lua_State* l) {
     movement.set_smooth(smooth);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1023,7 +1001,7 @@ TargetMovement& LuaContext::check_target_movement(lua_State* l, int index) {
  */
 int LuaContext::target_movement_api_set_target(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TargetMovement& movement = check_target_movement(l, 1);
     if (lua_isnumber(l, 2)) {
       // The target is a fixed point.
@@ -1045,8 +1023,7 @@ int LuaContext::target_movement_api_set_target(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1056,12 +1033,11 @@ int LuaContext::target_movement_api_set_target(lua_State* l) {
  */
 int LuaContext::target_movement_api_get_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TargetMovement& movement = check_target_movement(l, 1);
     lua_pushinteger(l, movement.get_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1071,13 +1047,12 @@ int LuaContext::target_movement_api_get_speed(lua_State* l) {
  */
 int LuaContext::target_movement_api_set_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TargetMovement& movement = check_target_movement(l, 1);
     int speed = LuaTools::check_int(l, 2);
     movement.set_moving_speed(speed);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1087,12 +1062,11 @@ int LuaContext::target_movement_api_set_speed(lua_State* l) {
  */
 int LuaContext::target_movement_api_get_angle(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TargetMovement& movement = check_target_movement(l, 1);
     lua_pushnumber(l, movement.get_angle());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1102,12 +1076,11 @@ int LuaContext::target_movement_api_get_angle(lua_State* l) {
  */
 int LuaContext::target_movement_api_is_smooth(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TargetMovement& movement = check_target_movement(l, 1);
     lua_pushboolean(l, movement.is_smooth());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1117,7 +1090,7 @@ int LuaContext::target_movement_api_is_smooth(lua_State* l) {
  */
 int LuaContext::target_movement_api_set_smooth(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TargetMovement& movement = check_target_movement(l, 1);
     bool smooth = true; // true if unspecified
     if (lua_gettop(l) >= 2) {
@@ -1126,8 +1099,7 @@ int LuaContext::target_movement_api_set_smooth(lua_State* l) {
     movement.set_smooth(smooth);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1160,7 +1132,7 @@ PathMovement& LuaContext::check_path_movement(lua_State* l, int index) {
  */
 int LuaContext::path_movement_api_get_path(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathMovement& movement = check_path_movement(l, 1);
 
     const std::string& path = movement.get_path();
@@ -1174,8 +1146,7 @@ int LuaContext::path_movement_api_get_path(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1185,7 +1156,7 @@ int LuaContext::path_movement_api_get_path(lua_State* l) {
  */
 int LuaContext::path_movement_api_set_path(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathMovement& movement = check_path_movement(l, 1);
     LuaTools::check_type(l, 2, LUA_TTABLE);
 
@@ -1200,8 +1171,7 @@ int LuaContext::path_movement_api_set_path(lua_State* l) {
     movement.set_path(path);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1211,12 +1181,11 @@ int LuaContext::path_movement_api_set_path(lua_State* l) {
  */
 int LuaContext::path_movement_api_get_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathMovement& movement = check_path_movement(l, 1);
     lua_pushinteger(l, movement.get_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1226,13 +1195,12 @@ int LuaContext::path_movement_api_get_speed(lua_State* l) {
  */
 int LuaContext::path_movement_api_set_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathMovement& movement = check_path_movement(l, 1);
     int speed = LuaTools::check_int(l, 2);
     movement.set_speed(speed);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1242,12 +1210,11 @@ int LuaContext::path_movement_api_set_speed(lua_State* l) {
  */
 int LuaContext::path_movement_api_get_loop(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathMovement& movement = check_path_movement(l, 1);
     lua_pushboolean(l, movement.get_loop());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1257,7 +1224,7 @@ int LuaContext::path_movement_api_get_loop(lua_State* l) {
  */
 int LuaContext::path_movement_api_set_loop(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathMovement& movement = check_path_movement(l, 1);
     bool loop = true; // true if unspecified
     if (lua_gettop(l) >= 2) {
@@ -1266,8 +1233,7 @@ int LuaContext::path_movement_api_set_loop(lua_State* l) {
     movement.set_loop(loop);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1277,12 +1243,11 @@ int LuaContext::path_movement_api_set_loop(lua_State* l) {
  */
 int LuaContext::path_movement_api_get_snap_to_grid(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathMovement& movement = check_path_movement(l, 1);
     lua_pushboolean(l, movement.get_snap_to_grid());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1292,7 +1257,7 @@ int LuaContext::path_movement_api_get_snap_to_grid(lua_State* l) {
  */
 int LuaContext::path_movement_api_set_snap_to_grid(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathMovement& movement = check_path_movement(l, 1);
     bool snap_to_grid = true; // true if unspecified
     if (lua_gettop(l) >= 2) {
@@ -1301,8 +1266,7 @@ int LuaContext::path_movement_api_set_snap_to_grid(lua_State* l) {
     movement.set_snap_to_grid(snap_to_grid);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1335,12 +1299,11 @@ bool LuaContext::is_random_path_movement(lua_State* l, int index) {
  */
 int LuaContext::random_path_movement_api_get_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomPathMovement& movement = check_random_path_movement(l, 1);
     lua_pushinteger(l, movement.get_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1350,13 +1313,12 @@ int LuaContext::random_path_movement_api_get_speed(lua_State* l) {
  */
 int LuaContext::random_path_movement_api_set_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     RandomPathMovement& movement = check_random_path_movement(l, 1);
     int speed = LuaTools::check_int(l, 2);
     movement.set_speed(speed);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1389,15 +1351,14 @@ PathFindingMovement& LuaContext::check_path_finding_movement(lua_State* l, int i
  */
 int LuaContext::path_finding_movement_api_set_target(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathFindingMovement& movement = check_path_finding_movement(l, 1);
     const std::shared_ptr<MapEntity>& target = check_entity(l, 2);
 
     movement.set_target(target);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1407,12 +1368,11 @@ int LuaContext::path_finding_movement_api_set_target(lua_State* l) {
  */
 int LuaContext::path_finding_movement_api_get_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathFindingMovement& movement = check_path_finding_movement(l, 1);
     lua_pushinteger(l, movement.get_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1422,13 +1382,12 @@ int LuaContext::path_finding_movement_api_get_speed(lua_State* l) {
  */
 int LuaContext::path_finding_movement_api_set_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PathFindingMovement& movement = check_path_finding_movement(l, 1);
     int speed = LuaTools::check_int(l, 2);
     movement.set_speed(speed);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1461,7 +1420,7 @@ CircleMovement& LuaContext::check_circle_movement(lua_State* l, int index) {
  */
 int LuaContext::circle_movement_api_set_center(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     if (lua_isnumber(l, 2)) {
       // the center is a fixed point
@@ -1479,8 +1438,7 @@ int LuaContext::circle_movement_api_set_center(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1490,12 +1448,11 @@ int LuaContext::circle_movement_api_set_center(lua_State* l) {
  */
 int LuaContext::circle_movement_api_get_radius(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     lua_pushinteger(l, movement.get_radius());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1505,13 +1462,12 @@ int LuaContext::circle_movement_api_get_radius(lua_State* l) {
  */
 int LuaContext::circle_movement_api_set_radius(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     int radius = LuaTools::check_int(l, 2);
     movement.set_radius(radius);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1521,12 +1477,11 @@ int LuaContext::circle_movement_api_set_radius(lua_State* l) {
  */
 int LuaContext::circle_movement_api_get_radius_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     lua_pushinteger(l, movement.get_radius_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1536,13 +1491,12 @@ int LuaContext::circle_movement_api_get_radius_speed(lua_State* l) {
  */
 int LuaContext::circle_movement_api_set_radius_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     int radius_speed = LuaTools::check_int(l, 2);
     movement.set_radius_speed(radius_speed);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1552,12 +1506,11 @@ int LuaContext::circle_movement_api_set_radius_speed(lua_State* l) {
  */
 int LuaContext::circle_movement_api_is_clockwise(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     lua_pushboolean(l, movement.is_clockwise());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1567,7 +1520,7 @@ int LuaContext::circle_movement_api_is_clockwise(lua_State* l) {
  */
 int LuaContext::circle_movement_api_set_clockwise(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     bool clockwise = true; // true if unspecified
     if (lua_gettop(l) >= 2) {
@@ -1576,8 +1529,7 @@ int LuaContext::circle_movement_api_set_clockwise(lua_State* l) {
     movement.set_clockwise(clockwise);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1587,12 +1539,11 @@ int LuaContext::circle_movement_api_set_clockwise(lua_State* l) {
  */
 int LuaContext::circle_movement_api_get_initial_angle(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     lua_pushnumber(l, movement.get_initial_angle());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1602,13 +1553,12 @@ int LuaContext::circle_movement_api_get_initial_angle(lua_State* l) {
  */
 int LuaContext::circle_movement_api_set_initial_angle(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     double initial_angle = LuaTools::check_number(l, 2);
     movement.set_initial_angle(initial_angle);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1618,12 +1568,11 @@ int LuaContext::circle_movement_api_set_initial_angle(lua_State* l) {
  */
 int LuaContext::circle_movement_api_get_angle_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     lua_pushinteger(l, movement.get_angle_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1633,13 +1582,12 @@ int LuaContext::circle_movement_api_get_angle_speed(lua_State* l) {
  */
 int LuaContext::circle_movement_api_set_angle_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     int angle_speed = LuaTools::check_int(l, 2);
     movement.set_angle_speed(angle_speed);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1649,12 +1597,11 @@ int LuaContext::circle_movement_api_set_angle_speed(lua_State* l) {
  */
 int LuaContext::circle_movement_api_get_max_rotations(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     lua_pushinteger(l, movement.get_max_rotations());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1664,13 +1611,12 @@ int LuaContext::circle_movement_api_get_max_rotations(lua_State* l) {
  */
 int LuaContext::circle_movement_api_set_max_rotations(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     int max_rotations = LuaTools::check_int(l, 2);
     movement.set_max_rotations(max_rotations);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1680,12 +1626,11 @@ int LuaContext::circle_movement_api_set_max_rotations(lua_State* l) {
  */
 int LuaContext::circle_movement_api_get_duration(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     lua_pushinteger(l, movement.get_duration());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1695,13 +1640,12 @@ int LuaContext::circle_movement_api_get_duration(lua_State* l) {
  */
 int LuaContext::circle_movement_api_set_duration(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     int duration = LuaTools::check_int(l, 2);
     movement.set_duration(duration);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1711,12 +1655,11 @@ int LuaContext::circle_movement_api_set_duration(lua_State* l) {
  */
 int LuaContext::circle_movement_api_get_loop_delay(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     lua_pushinteger(l, movement.get_loop());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1726,13 +1669,12 @@ int LuaContext::circle_movement_api_get_loop_delay(lua_State* l) {
  */
 int LuaContext::circle_movement_api_set_loop_delay(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     CircleMovement& movement = check_circle_movement(l, 1);
     int loop_delay = LuaTools::check_int(l, 2);
     movement.set_loop(loop_delay);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1765,12 +1707,11 @@ JumpMovement& LuaContext::check_jump_movement(lua_State* l, int index) {
  */
 int LuaContext::jump_movement_api_get_direction8(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     JumpMovement& movement = check_jump_movement(l, 1);
     lua_pushinteger(l, movement.get_direction8());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1780,13 +1721,12 @@ int LuaContext::jump_movement_api_get_direction8(lua_State* l) {
  */
 int LuaContext::jump_movement_api_set_direction8(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     JumpMovement& movement = check_jump_movement(l, 1);
     int direction8 = LuaTools::check_int(l, 2);
     movement.set_direction8(direction8);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1796,12 +1736,11 @@ int LuaContext::jump_movement_api_set_direction8(lua_State* l) {
  */
 int LuaContext::jump_movement_api_get_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     JumpMovement& movement = check_jump_movement(l, 1);
     lua_pushinteger(l, movement.get_distance());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1811,13 +1750,12 @@ int LuaContext::jump_movement_api_get_distance(lua_State* l) {
  */
 int LuaContext::jump_movement_api_set_distance(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     JumpMovement& movement = check_jump_movement(l, 1);
     int distance = LuaTools::check_int(l, 2);
     movement.set_distance(distance);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1827,12 +1765,11 @@ int LuaContext::jump_movement_api_set_distance(lua_State* l) {
  */
 int LuaContext::jump_movement_api_get_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     JumpMovement& movement = check_jump_movement(l, 1);
     lua_pushinteger(l, movement.get_speed());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1842,13 +1779,12 @@ int LuaContext::jump_movement_api_get_speed(lua_State* l) {
  */
 int LuaContext::jump_movement_api_set_speed(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     JumpMovement& movement = check_jump_movement(l, 1);
     int speed = LuaTools::check_int(l, 2);
     movement.set_speed(speed);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1881,7 +1817,7 @@ PixelMovement& LuaContext::check_pixel_movement(lua_State* l, int index) {
  */
 int LuaContext::pixel_movement_api_get_trajectory(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PixelMovement& movement = check_pixel_movement(l, 1);
 
     const std::list<Point>& trajectory = movement.get_trajectory();
@@ -1900,8 +1836,7 @@ int LuaContext::pixel_movement_api_get_trajectory(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1911,7 +1846,7 @@ int LuaContext::pixel_movement_api_get_trajectory(lua_State* l) {
  */
 int LuaContext::pixel_movement_api_set_trajectory(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PixelMovement& movement = check_pixel_movement(l, 1);
     LuaTools::check_type(l, 2, LUA_TTABLE);
 
@@ -1930,8 +1865,7 @@ int LuaContext::pixel_movement_api_set_trajectory(lua_State* l) {
     movement.set_trajectory(trajectory);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1941,12 +1875,11 @@ int LuaContext::pixel_movement_api_set_trajectory(lua_State* l) {
  */
 int LuaContext::pixel_movement_api_get_loop(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PixelMovement& movement = check_pixel_movement(l, 1);
     lua_pushboolean(l, movement.get_loop());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1956,7 +1889,7 @@ int LuaContext::pixel_movement_api_get_loop(lua_State* l) {
  */
 int LuaContext::pixel_movement_api_set_loop(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PixelMovement& movement = check_pixel_movement(l, 1);
     bool loop = true; // true if unspecified
     if (lua_gettop(l) >= 2) {
@@ -1965,8 +1898,7 @@ int LuaContext::pixel_movement_api_set_loop(lua_State* l) {
     movement.set_loop(loop);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1976,12 +1908,11 @@ int LuaContext::pixel_movement_api_set_loop(lua_State* l) {
  */
 int LuaContext::pixel_movement_api_get_delay(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PixelMovement& movement = check_pixel_movement(l, 1);
     lua_pushinteger(l, movement.get_delay());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -1991,13 +1922,12 @@ int LuaContext::pixel_movement_api_get_delay(lua_State* l) {
  */
 int LuaContext::pixel_movement_api_set_delay(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     PixelMovement& movement = check_pixel_movement(l, 1);
     uint32_t delay = uint32_t(LuaTools::check_int(l, 2));
     movement.set_delay(delay);
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/SpriteApi.cpp
+++ b/src/lua/SpriteApi.cpp
@@ -115,7 +115,7 @@ void LuaContext::push_sprite(lua_State* l, Sprite& sprite) {
  */
 int LuaContext::sprite_api_create(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& animation_set_id = LuaTools::check_string(l, 1);
 
     // TODO if the file does not exist, make a Lua error instead of an assertion error.
@@ -124,8 +124,7 @@ int LuaContext::sprite_api_create(lua_State* l) {
 
     push_sprite(l, *sprite);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -135,15 +134,14 @@ int LuaContext::sprite_api_create(lua_State* l) {
  */
 int LuaContext::sprite_api_get_animation_set(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Sprite& sprite = *check_sprite(l, 1);
 
     const std::string& animation_set_id = sprite.get_animation_set_id();
 
     push_string(l, animation_set_id);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -153,15 +151,14 @@ int LuaContext::sprite_api_get_animation_set(lua_State* l) {
  */
 int LuaContext::sprite_api_get_animation(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Sprite& sprite = *check_sprite(l, 1);
 
     const std::string& animation_name = sprite.get_current_animation();
 
     push_string(l, animation_name);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -171,7 +168,7 @@ int LuaContext::sprite_api_get_animation(lua_State* l) {
  */
 int LuaContext::sprite_api_set_animation(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Sprite& sprite = *check_sprite(l, 1);
 
     const std::string& animation_name = LuaTools::check_string(l, 2);
@@ -186,8 +183,7 @@ int LuaContext::sprite_api_set_animation(lua_State* l) {
     sprite.restart_animation();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -197,14 +193,13 @@ int LuaContext::sprite_api_set_animation(lua_State* l) {
  */
 int LuaContext::sprite_api_has_animation(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Sprite& sprite = *check_sprite(l, 1);
     const std::string& animation_name = LuaTools::check_string(l, 2);
 
     lua_pushboolean(l, sprite.has_animation(animation_name));
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -214,13 +209,12 @@ int LuaContext::sprite_api_has_animation(lua_State* l) {
  */
 int LuaContext::sprite_api_get_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Sprite& sprite = *check_sprite(l, 1);
 
     lua_pushinteger(l, sprite.get_current_direction());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -230,7 +224,7 @@ int LuaContext::sprite_api_get_direction(lua_State* l) {
  */
 int LuaContext::sprite_api_set_direction(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Sprite& sprite = *check_sprite(l, 1);
     int direction = LuaTools::check_int(l, 2);
 
@@ -244,8 +238,7 @@ int LuaContext::sprite_api_set_direction(lua_State* l) {
     sprite.set_current_direction(direction);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -255,7 +248,7 @@ int LuaContext::sprite_api_set_direction(lua_State* l) {
  */
 int LuaContext::sprite_api_get_num_directions(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Sprite& sprite = *check_sprite(l, 1);
     const std::string& animation_name = LuaTools::opt_string(l, 2, sprite.get_current_animation());
     if (!sprite.has_animation(animation_name)) {
@@ -269,8 +262,7 @@ int LuaContext::sprite_api_get_num_directions(lua_State* l) {
 
     lua_pushinteger(l, num_directions);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -280,13 +272,12 @@ int LuaContext::sprite_api_get_num_directions(lua_State* l) {
  */
 int LuaContext::sprite_api_get_frame(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Sprite& sprite = *check_sprite(l, 1);
 
     lua_pushinteger(l, sprite.get_current_frame());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -296,7 +287,7 @@ int LuaContext::sprite_api_get_frame(lua_State* l) {
  */
 int LuaContext::sprite_api_set_frame(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Sprite& sprite = *check_sprite(l, 1);
     int frame = LuaTools::check_int(l, 2);
 
@@ -311,8 +302,7 @@ int LuaContext::sprite_api_set_frame(lua_State* l) {
     sprite.set_current_frame(frame);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -322,7 +312,7 @@ int LuaContext::sprite_api_set_frame(lua_State* l) {
  */
 int LuaContext::sprite_api_get_frame_delay(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Sprite& sprite = *check_sprite(l, 1);
 
     uint32_t frame_delay = sprite.get_frame_delay();
@@ -334,8 +324,7 @@ int LuaContext::sprite_api_get_frame_delay(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -345,7 +334,7 @@ int LuaContext::sprite_api_get_frame_delay(lua_State* l) {
  */
 int LuaContext::sprite_api_set_frame_delay(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Sprite& sprite = *check_sprite(l, 1);
     uint32_t delay = 0;
     if (!lua_isnil(l, 2)) {
@@ -355,8 +344,7 @@ int LuaContext::sprite_api_set_frame_delay(lua_State* l) {
     sprite.set_frame_delay(delay);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -366,14 +354,13 @@ int LuaContext::sprite_api_set_frame_delay(lua_State* l) {
  */
 int LuaContext::sprite_api_is_paused(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Sprite& sprite = *check_sprite(l, 1);
 
     lua_pushboolean(l, sprite.is_paused());
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -383,7 +370,7 @@ int LuaContext::sprite_api_is_paused(lua_State* l) {
  */
 int LuaContext::sprite_api_set_paused(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Sprite& sprite = *check_sprite(l, 1);
     bool paused = true;  // true if unspecified.
     if (lua_gettop(l) >= 2) {
@@ -393,8 +380,7 @@ int LuaContext::sprite_api_set_paused(lua_State* l) {
     sprite.set_paused(paused);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -404,7 +390,7 @@ int LuaContext::sprite_api_set_paused(lua_State* l) {
  */
 int LuaContext::sprite_api_set_ignore_suspend(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Sprite& sprite = *check_sprite(l, 1);
     bool ignore_suspend = true;  // true if unspecified.
     if (lua_gettop(l) >= 2) {
@@ -414,8 +400,7 @@ int LuaContext::sprite_api_set_ignore_suspend(lua_State *l) {
     sprite.set_ignore_suspend(ignore_suspend);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -425,7 +410,7 @@ int LuaContext::sprite_api_set_ignore_suspend(lua_State *l) {
  */
 int LuaContext::sprite_api_synchronize(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::shared_ptr<Sprite>& sprite = check_sprite(l, 1);
 
     if (!lua_isnil(l, 2)) {
@@ -437,8 +422,7 @@ int LuaContext::sprite_api_synchronize(lua_State *l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**

--- a/src/lua/SurfaceApi.cpp
+++ b/src/lua/SurfaceApi.cpp
@@ -103,7 +103,7 @@ void LuaContext::push_surface(lua_State* l, Surface& surface) {
  */
 int LuaContext::surface_api_create(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     SurfacePtr surface;
     if (lua_gettop(l) == 0) {
       // create an empty surface with the screen size
@@ -135,8 +135,7 @@ int LuaContext::surface_api_create(lua_State* l) {
       push_surface(l, *surface);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -146,14 +145,13 @@ int LuaContext::surface_api_create(lua_State* l) {
  */
 int LuaContext::surface_api_get_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Surface& surface = *check_surface(l, 1);
 
     lua_pushinteger(l, surface.get_width());
     lua_pushinteger(l, surface.get_height());
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -163,14 +161,13 @@ int LuaContext::surface_api_get_size(lua_State* l) {
  */
 int LuaContext::surface_api_clear(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Surface& surface = *check_surface(l, 1);
 
     surface.clear();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -180,7 +177,7 @@ int LuaContext::surface_api_clear(lua_State* l) {
  */
 int LuaContext::surface_api_fill_color(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Surface& surface = *check_surface(l, 1);
     Color color = LuaTools::check_color(l, 2);
 
@@ -197,8 +194,7 @@ int LuaContext::surface_api_fill_color(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -208,15 +204,14 @@ int LuaContext::surface_api_fill_color(lua_State* l) {
  */
 int LuaContext::surface_api_set_opacity(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Surface& surface = *check_surface(l, 1);
     uint8_t opacity = (uint8_t) LuaTools::check_int(l, 2);
 
     surface.set_opacity(opacity);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lua/TextSurfaceApi.cpp
+++ b/src/lua/TextSurfaceApi.cpp
@@ -135,7 +135,7 @@ void LuaContext::push_text_surface(lua_State* l, TextSurface& text_surface) {
  */
 int LuaContext::text_surface_api_create(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurfacePtr text_surface = RefCountable::make_refcount_ptr(new TextSurface(0, 0));
 
     if (lua_gettop(l) > 0) {
@@ -198,8 +198,7 @@ int LuaContext::text_surface_api_create(lua_State* l) {
 
     push_text_surface(l, *text_surface);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -209,15 +208,14 @@ int LuaContext::text_surface_api_create(lua_State* l) {
  */
 int LuaContext::text_surface_api_get_horizontal_alignment(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
 
     TextSurface::HorizontalAlignment alignment = text_surface.get_horizontal_alignment();
 
     push_string(l, horizontal_alignment_names[alignment]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -227,7 +225,7 @@ int LuaContext::text_surface_api_get_horizontal_alignment(lua_State* l) {
  */
 int LuaContext::text_surface_api_set_horizontal_alignment(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
     TextSurface::HorizontalAlignment alignment =
         LuaTools::check_enum<TextSurface::HorizontalAlignment>(
@@ -236,8 +234,7 @@ int LuaContext::text_surface_api_set_horizontal_alignment(lua_State* l) {
     text_surface.set_horizontal_alignment(alignment);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -247,15 +244,14 @@ int LuaContext::text_surface_api_set_horizontal_alignment(lua_State* l) {
  */
 int LuaContext::text_surface_api_get_vertical_alignment(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
 
     TextSurface::VerticalAlignment alignment = text_surface.get_vertical_alignment();
 
     push_string(l, vertical_alignment_names[alignment]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -265,7 +261,7 @@ int LuaContext::text_surface_api_get_vertical_alignment(lua_State* l) {
  */
 int LuaContext::text_surface_api_set_vertical_alignment(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
     TextSurface::VerticalAlignment alignment =
         LuaTools::check_enum<TextSurface::VerticalAlignment>(
@@ -274,8 +270,7 @@ int LuaContext::text_surface_api_set_vertical_alignment(lua_State* l) {
     text_surface.set_vertical_alignment(alignment);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -285,15 +280,14 @@ int LuaContext::text_surface_api_set_vertical_alignment(lua_State* l) {
  */
 int LuaContext::text_surface_api_get_font(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
 
     const std::string& font_id = text_surface.get_font();
     push_string(l, font_id);
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -303,7 +297,7 @@ int LuaContext::text_surface_api_get_font(lua_State* l) {
  */
 int LuaContext::text_surface_api_set_font(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
     const std::string& font_id = LuaTools::check_string(l, 2);
 
@@ -313,8 +307,7 @@ int LuaContext::text_surface_api_set_font(lua_State* l) {
     text_surface.set_font(font_id);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -324,15 +317,14 @@ int LuaContext::text_surface_api_set_font(lua_State* l) {
  */
 int LuaContext::text_surface_api_get_rendering_mode(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
 
     TextSurface::RenderingMode mode = text_surface.get_rendering_mode();
 
     push_string(l, rendering_mode_names[mode]);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -342,7 +334,7 @@ int LuaContext::text_surface_api_get_rendering_mode(lua_State* l) {
  */
 int LuaContext::text_surface_api_set_rendering_mode(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
     TextSurface::RenderingMode mode = LuaTools::check_enum<TextSurface::RenderingMode>(
         l, 1, rendering_mode_names);
@@ -350,8 +342,7 @@ int LuaContext::text_surface_api_set_rendering_mode(lua_State* l) {
     text_surface.set_rendering_mode(mode);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -361,15 +352,14 @@ int LuaContext::text_surface_api_set_rendering_mode(lua_State* l) {
  */
 int LuaContext::text_surface_api_get_color(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
 
     const Color& color = text_surface.get_text_color();
 
     push_color(l, color);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -379,15 +369,14 @@ int LuaContext::text_surface_api_get_color(lua_State* l) {
  */
 int LuaContext::text_surface_api_set_color(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
     const Color& color = LuaTools::check_color(l, 2);
 
     text_surface.set_text_color(color);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -397,15 +386,14 @@ int LuaContext::text_surface_api_set_color(lua_State* l) {
  */
 int LuaContext::text_surface_api_get_text(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
 
     const std::string& text = text_surface.get_text();
 
     push_string(l, text);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -415,7 +403,7 @@ int LuaContext::text_surface_api_get_text(lua_State* l) {
  */
 int LuaContext::text_surface_api_set_text(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
     std::string text;
     if (lua_gettop(l) >= 2 && !lua_isnil(l, 2)) {
@@ -424,8 +412,7 @@ int LuaContext::text_surface_api_set_text(lua_State* l) {
     text_surface.set_text(text);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -435,7 +422,7 @@ int LuaContext::text_surface_api_set_text(lua_State* l) {
  */
 int LuaContext::text_surface_api_set_text_key(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
     const std::string& key = LuaTools::check_string(l, 2);
 
@@ -449,8 +436,7 @@ int LuaContext::text_surface_api_set_text_key(lua_State* l) {
     text_surface.set_text(StringResource::get_string(key));
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -460,15 +446,14 @@ int LuaContext::text_surface_api_set_text_key(lua_State* l) {
  */
 int LuaContext::text_surface_api_get_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     TextSurface& text_surface = check_text_surface(l, 1);
 
     lua_pushinteger(l, text_surface.get_width());
     lua_pushinteger(l, text_surface.get_height());
 
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lua/TimerApi.cpp
+++ b/src/lua/TimerApi.cpp
@@ -345,7 +345,7 @@ void LuaContext::do_timer_callback(const TimerPtr& timer) {
  */
 int LuaContext::timer_api_start(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     // Parameters: [context] delay callback.
     LuaContext& lua_context = get_lua_context(l);
 
@@ -388,8 +388,7 @@ int LuaContext::timer_api_start(lua_State *l) {
     push_timer(l, timer);
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -399,14 +398,13 @@ int LuaContext::timer_api_start(lua_State *l) {
  */
 int LuaContext::timer_api_stop(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
     const TimerPtr& timer = check_timer(l, 1);
     lua_context.remove_timer(timer);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -416,7 +414,7 @@ int LuaContext::timer_api_stop(lua_State* l) {
  */
 int LuaContext::timer_api_stop_all(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     if (lua_type(l, 1) != LUA_TTABLE
         && lua_type(l, 1) != LUA_TUSERDATA) {
       LuaTools::type_error(l, 1, "table or userdata");
@@ -425,8 +423,7 @@ int LuaContext::timer_api_stop_all(lua_State* l) {
     get_lua_context(l).remove_timers(1);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -436,13 +433,12 @@ int LuaContext::timer_api_stop_all(lua_State* l) {
  */
 int LuaContext::timer_api_is_with_sound(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const TimerPtr& timer = check_timer(l, 1);
 
     lua_pushboolean(l, timer->is_with_sound());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -452,7 +448,7 @@ int LuaContext::timer_api_is_with_sound(lua_State* l) {
  */
 int LuaContext::timer_api_set_with_sound(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const TimerPtr& timer = check_timer(l, 1);
     bool with_sound = true;
     if (lua_gettop(l) >= 2) {
@@ -462,8 +458,7 @@ int LuaContext::timer_api_set_with_sound(lua_State* l) {
     timer->set_with_sound(with_sound);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -473,13 +468,12 @@ int LuaContext::timer_api_set_with_sound(lua_State* l) {
  */
 int LuaContext::timer_api_is_suspended(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const TimerPtr& timer = check_timer(l, 1);
 
     lua_pushboolean(l, timer->is_suspended());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -489,7 +483,7 @@ int LuaContext::timer_api_is_suspended(lua_State* l) {
  */
 int LuaContext::timer_api_set_suspended(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const TimerPtr& timer = check_timer(l, 1);
     bool suspended = true;
     if (lua_gettop(l) >= 2) {
@@ -499,8 +493,7 @@ int LuaContext::timer_api_set_suspended(lua_State* l) {
     timer->set_suspended(suspended);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -510,13 +503,12 @@ int LuaContext::timer_api_set_suspended(lua_State* l) {
  */
 int LuaContext::timer_api_is_suspended_with_map(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const TimerPtr& timer = check_timer(l, 1);
 
     lua_pushboolean(l, timer->is_suspended_with_map());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -526,7 +518,7 @@ int LuaContext::timer_api_is_suspended_with_map(lua_State* l) {
  */
 int LuaContext::timer_api_set_suspended_with_map(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     LuaContext& lua_context = get_lua_context(l);
 
     const TimerPtr& timer = check_timer(l, 1);
@@ -544,8 +536,7 @@ int LuaContext::timer_api_set_suspended_with_map(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -555,7 +546,7 @@ int LuaContext::timer_api_set_suspended_with_map(lua_State* l) {
  */
 int LuaContext::timer_api_get_remaining_time(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const TimerPtr& timer = check_timer(l, 1);
 
     LuaContext& lua_context = get_lua_context(l);
@@ -573,8 +564,7 @@ int LuaContext::timer_api_get_remaining_time(lua_State* l) {
       lua_pushinteger(l, remaining_time);
     }
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -584,7 +574,7 @@ int LuaContext::timer_api_get_remaining_time(lua_State* l) {
  */
 int LuaContext::timer_api_set_remaining_time(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const TimerPtr& timer = check_timer(l, 1);
     uint32_t remaining_time = LuaTools::check_int(l, 2);
 
@@ -603,8 +593,7 @@ int LuaContext::timer_api_set_remaining_time(lua_State* l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }

--- a/src/lua/VideoApi.cpp
+++ b/src/lua/VideoApi.cpp
@@ -59,14 +59,13 @@ void LuaContext::register_video_module() {
  */
 int LuaContext::video_api_get_window_title(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& window_title =
         Video::get_window_title();
 
     push_string(l, window_title);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -76,13 +75,12 @@ int LuaContext::video_api_get_window_title(lua_State *l) {
  */
 int LuaContext::video_api_set_window_title(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::string& window_title = LuaTools::check_string(l, 1);
 
     Video::set_window_title(window_title);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -92,13 +90,12 @@ int LuaContext::video_api_set_window_title(lua_State *l) {
  */
 int LuaContext::video_api_get_mode(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const VideoMode& mode = Video::get_video_mode();
 
     push_string(l, mode.get_name());
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -108,7 +105,7 @@ int LuaContext::video_api_get_mode(lua_State *l) {
  */
 int LuaContext::video_api_set_mode(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::string mode_name = LuaTools::check_string(l, 1);
     const VideoMode* mode = Video::get_video_mode_by_name(mode_name);
 
@@ -117,8 +114,7 @@ int LuaContext::video_api_set_mode(lua_State *l) {
     }
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -128,12 +124,11 @@ int LuaContext::video_api_set_mode(lua_State *l) {
  */
 int LuaContext::video_api_switch_mode(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Video::switch_video_mode();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -143,7 +138,7 @@ int LuaContext::video_api_switch_mode(lua_State* l) {
  */
 int LuaContext::video_api_get_modes(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const std::vector<const VideoMode*>& modes =
         Video::get_video_modes();
 
@@ -157,8 +152,7 @@ int LuaContext::video_api_get_modes(lua_State* l) {
     }
 
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -168,7 +162,7 @@ int LuaContext::video_api_get_modes(lua_State* l) {
  */
 int LuaContext::video_api_is_mode_supported(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     std::string mode_name = LuaTools::check_string(l, 1);
     const VideoMode* mode = Video::get_video_mode_by_name(mode_name);
 
@@ -176,8 +170,7 @@ int LuaContext::video_api_is_mode_supported(lua_State *l) {
 
     lua_pushboolean(l, supported);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -187,13 +180,12 @@ int LuaContext::video_api_is_mode_supported(lua_State *l) {
  */
 int LuaContext::video_api_is_fullscreen(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     bool fullscreen = Video::is_fullscreen();
 
     lua_pushboolean(l, fullscreen);
     return 1;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -203,7 +195,7 @@ int LuaContext::video_api_is_fullscreen(lua_State *l) {
  */
 int LuaContext::video_api_set_fullscreen(lua_State *l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     bool fullscreen = true;  // true if unspecified.
     if (lua_gettop(l) >= 1) {
       fullscreen = lua_toboolean(l, 1);
@@ -212,8 +204,7 @@ int LuaContext::video_api_set_fullscreen(lua_State *l) {
     Video::set_fullscreen(fullscreen);
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -223,14 +214,13 @@ int LuaContext::video_api_set_fullscreen(lua_State *l) {
  */
 int LuaContext::video_api_get_quest_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Size& quest_size = Video::get_quest_size();
 
     lua_pushinteger(l, quest_size.width);
     lua_pushinteger(l, quest_size.height);
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -240,14 +230,13 @@ int LuaContext::video_api_get_quest_size(lua_State* l) {
  */
 int LuaContext::video_api_get_window_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     const Size& window_size = Video::get_window_size();
 
     lua_pushinteger(l, window_size.width);
     lua_pushinteger(l, window_size.height);
     return 2;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -257,7 +246,7 @@ int LuaContext::video_api_get_window_size(lua_State* l) {
  */
 int LuaContext::video_api_set_window_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     int width = LuaTools::check_int(l, 1);
     int height = LuaTools::check_int(l, 2);
 
@@ -271,8 +260,7 @@ int LuaContext::video_api_set_window_size(lua_State* l) {
     Video::set_window_size(Size(width, height));
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 /**
@@ -282,12 +270,11 @@ int LuaContext::video_api_set_window_size(lua_State* l) {
  */
 int LuaContext::video_api_reset_window_size(lua_State* l) {
 
-  SOLARUS_LUA_BOUNDARY_TRY() {
+  return LuaTools::exception_boundary_handle(l, [&] {
     Video::reset_window_size();
 
     return 0;
-  }
-  SOLARUS_LUA_BOUNDARY_CATCH(l);
+  });
 }
 
 }


### PR DESCRIPTION
I removed the macros SOLARUS_LUA_BOUNDARY_TRY and SOLARUS_LUA_BOUNDARY_CATCH and replaced them by a lambda-based solution: LuaTools::exception_boundary_handle. I took the modern boundary design from this article: http://blogs.msdn.com/b/vcblog/archive/2014/01/16/exception-boundaries.aspx

This patch may also have fix a potential issue: one of the return statements was outside of the exception boundary try/catch block, but the macro solution couldn't catch that.
