### PR TITLE
Fixed remaining macro.

### DIFF
--- a/src/QuestResourceList.cpp
+++ b/src/QuestResourceList.cpp
@@ -59,8 +59,7 @@ namespace {
       resource_map[resource_type][id] = description;
 
       return 0;
-    }
-    SOLARUS_LUA_BOUNDARY_CATCH(l);
+    });
   }
 
 }


### PR DESCRIPTION
The multi-line search-and-replace did not catch the last SOLARUS_LUA_BOUNDARY_CATCH in an anonymous namespace. This commit fixes the error.
