### PR TITLE
Functions *_point now return Point instances instead of Rectangle ones.

### DIFF
--- a/include/Map.h
+++ b/include/Map.h
@@ -112,6 +112,7 @@ class Map: public ExportableToLua {
 
     // collisions with obstacles (checked before a move)
     bool test_collision_with_border(int x, int y) const;
+    bool test_collision_with_border(const Point& point) const;
     bool test_collision_with_border(const Rectangle& collision_box) const;
     bool test_collision_with_ground(
         Layer layer,
@@ -134,6 +135,11 @@ class Map: public ExportableToLua {
         Layer layer,
         int x,
         int y,
+        MapEntity& entity_to_check
+    ) const;
+    bool test_collision_with_obstacles(
+        Layer layer,
+        const Point& point,
         MapEntity& entity_to_check
     ) const;
     bool has_empty_ground(
@@ -224,13 +230,23 @@ class Map: public ExportableToLua {
 
 /**
  * \brief Tests whether a point is outside the map area.
- * \param x x of the point to check
- * \param y y of the point to check
- * \return true if this point is outside the map area
+ * \param x x of the point to check.
+ * \param y y of the point to check.
+ * \return true if this point is outside the map area.
  */
 inline bool Map::test_collision_with_border(int x, int y) const {
 
   return (x < 0 || y < 0 || x >= location.get_width() || y >= location.get_height());
+}
+
+/**
+ * \brief Tests whether a point is outside the map area.
+ * \param point point to check.
+ * \return true if this point is outside the map area.
+ */
+inline bool Map::test_collision_with_border(const Point& point) const {
+
+  return test_collision_with_border(point.x, point.y);
 }
 
 /**

--- a/include/entities/Hero.h
+++ b/include/entities/Hero.h
@@ -103,7 +103,7 @@ class Hero: public MapEntity {
      * the hero relative to other entities, and about
      * what is in front of him (we call this the "facing point").
      */
-    virtual const Rectangle get_facing_point() const override;
+    virtual const Point get_facing_point() const override;
     virtual void notify_facing_entity_changed(Detector* facing_entity) override;
     bool is_facing_obstacle();
     bool is_facing_point_on_obstacle();
@@ -146,7 +146,7 @@ class Hero: public MapEntity {
      */
     bool is_ground_visible() const;
     virtual bool is_ground_observer() const override;
-    virtual const Rectangle get_ground_point() const override;
+    virtual const Point get_ground_point() const override;
     virtual void notify_ground_below_changed() override;
     const Point& get_last_solid_ground_coords() const;
     Layer get_last_solid_ground_layer() const;

--- a/include/entities/MapEntity.h
+++ b/include/entities/MapEntity.h
@@ -96,7 +96,7 @@ class MapEntity: public ExportableToLua {
     virtual bool is_detector() const;
     virtual bool can_be_obstacle() const;
     virtual bool is_ground_observer() const;
-    virtual const Rectangle get_ground_point() const;
+    virtual const Point get_ground_point() const;
     virtual bool is_ground_modifier() const;
     virtual Ground get_modified_ground() const;
     virtual bool can_be_drawn() const;
@@ -151,9 +151,9 @@ class MapEntity: public ExportableToLua {
     void set_top_left_xy(int x, int y);
     void set_top_left_xy(const Point& xy);
 
-    virtual const Rectangle get_facing_point() const;
-    const Rectangle get_touching_point(int direction) const;
-    const Rectangle get_center_point() const;
+    virtual const Point get_facing_point() const;
+    const Point get_touching_point(int direction) const;
+    const Point get_center_point() const;
 
     bool is_aligned_to_grid() const;
     bool is_aligned_to_grid_x() const;

--- a/include/lowlevel/Rectangle.h
+++ b/include/lowlevel/Rectangle.h
@@ -77,7 +77,7 @@ class Rectangle {
     bool contains(const Point& point) const;
     bool contains(const Rectangle& other) const;
     bool overlaps(const Rectangle& other) const;
-    Rectangle get_center() const;
+    Point get_center() const;
 
     Rectangle get_intersection(const Rectangle& other) const;
 
@@ -175,15 +175,13 @@ inline Point Rectangle::get_xy() const {
 
 /**
  * \brief Returns the center point of this rectangle.
- * \return The center point, represented as a rectangle of size 1x1.
+ * \return The center point.
  */
-inline Rectangle Rectangle::get_center() const {
+inline Point Rectangle::get_center() const {
 
   return {
       get_x() + get_width() / 2,
       get_y() + get_height() / 2,
-      1,
-      1
   };
 }
 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -92,9 +92,9 @@ void Camera::update_fixed_on_hero() {
     // Normal case: not traversing a separator.
 
     // First compute the camera coordinates ignoring map borders and separators.
-    const Rectangle& hero_center = map.get_entities().get_hero().get_center_point();
-    const int hero_x = hero_center.get_x();
-    const int hero_y = hero_center.get_y();
+    const Point& hero_center = map.get_entities().get_hero().get_center_point();
+    const int hero_x = hero_center.x;
+    const int hero_y = hero_center.y;
     x = hero_x - get_width() / 2;
     y = hero_y - get_height() / 2;
 
@@ -351,8 +351,7 @@ void Camera::move(const Point& target) {
  */
 void Camera::move(MapEntity& entity) {
 
-  const Rectangle& center = entity.get_center_point();
-  move(center.get_xy());
+  move(entity.get_center_point());
 }
 
 /**
@@ -389,10 +388,10 @@ void Camera::traverse_separator(Separator* separator) {
   separator_scrolling_dy = 0;
   separator_target_position = position;
   Hero& hero = map.get_entities().get_hero();
-  const Rectangle& hero_center = hero.get_center_point();
-  const Rectangle& separator_center = separator->get_center_point();
+  const Point& hero_center = hero.get_center_point();
+  const Point& separator_center = separator->get_center_point();
   if (separator->is_horizontal()) {
-    if (hero_center.get_y() < separator_center.get_y()) {
+    if (hero_center.y < separator_center.y) {
       separator_scrolling_direction4 = 3;
       separator_scrolling_dy = 1;
       separator_target_position.add_y(get_height());
@@ -404,7 +403,7 @@ void Camera::traverse_separator(Separator* separator) {
     }
   }
   else {
-    if (hero_center.get_x() < separator_center.get_x()) {
+    if (hero_center.x < separator_center.x) {
       separator_scrolling_direction4 = 0;
       separator_scrolling_dx = 1;
       separator_target_position.add_x(get_width());

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -1020,6 +1020,22 @@ bool Map::test_collision_with_obstacles(
 }
 
 /**
+ * \brief Tests whether a point collides with the map obstacles.
+ * \param layer Layer of point to check.
+ * \param point Point to check.
+ * \param entity_to_check The entity to check (used to decide what is
+ * considered as obstacle)
+ * \return \c true if the point is overlapping an obstacle.
+ */
+bool Map::test_collision_with_obstacles(
+    Layer layer,
+    const Point& point,
+    MapEntity& entity_to_check) const {
+
+  return test_collision_with_obstacles(layer, point.x, point.y, entity_to_check);
+}
+
+/**
  * \brief Returns whether there is empty ground in the specified rectangle.
  *
  * Only the borders of the rectangle are checked.

--- a/src/entities/Arrow.cpp
+++ b/src/entities/Arrow.cpp
@@ -58,7 +58,7 @@ Arrow::Arrow(const Hero& hero):
     set_origin(4, 8);
   }
 
-  set_xy(hero.get_center_point().get_xy());
+  set_xy(hero.get_center_point());
   set_optimization_distance(0); // Make the arrow continue outside the screen until disappear_date.
 
   std::string path = " ";

--- a/src/entities/Bomb.cpp
+++ b/src/entities/Bomb.cpp
@@ -159,9 +159,8 @@ void Bomb::notify_collision_with_stream(Stream& stream, int /* dx */, int /* dy 
     // TODO use a StreamAction, since it now works with any entity and not only the hero.
 
     // Check that a significant part of the bomb is on the stream.
-    Rectangle center = get_center_point();
+    Rectangle center(get_center_point(), Size(2, 2));
     center.add_xy(-1, -1);
-    center.set_size(2, 2);
 
     if (stream.overlaps(center)) {
       set_xy(stream.get_xy());
@@ -269,7 +268,7 @@ void Bomb::update() {
 void Bomb::explode() {
 
   get_entities().add_entity(std::make_shared<Explosion>(
-      "", get_layer(), get_center_point().get_xy(), true
+      "", get_layer(), get_center_point(), true
   ));
   Sound::play("explosion");
   remove_from_map();

--- a/src/entities/CrystalBlock.cpp
+++ b/src/entities/CrystalBlock.cpp
@@ -117,16 +117,16 @@ void CrystalBlock::notify_collision(MapEntity& entity_overlapping, CollisionMode
       int jump_length = 0;
       bool jumped = false;
 
-      const Rectangle &hero_center = hero.get_center_point();
+      const Point& hero_center = hero.get_center_point();
 
-      if (hero_center.get_y() < y1) {
+      if (hero_center.y < y1) {
         // fall to the north
         collision_box.set_y(y1 - 16);
         jump_direction = 2;
         jump_length = hero.get_top_left_y() + 16 - y1;
         jumped = try_jump(hero, collision_box, jump_direction, jump_length);
       }
-      else if (hero_center.get_y() >= y2) {
+      else if (hero_center.y >= y2) {
         // fall to the south
         collision_box.set_y(y2);
         jump_direction = 6;
@@ -135,14 +135,14 @@ void CrystalBlock::notify_collision(MapEntity& entity_overlapping, CollisionMode
       }
 
       if (!jumped) {
-        if (hero_center.get_x() >= x2) {
+        if (hero_center.x >= x2) {
           // fall to the east
           collision_box.set_x(x2);
           jump_direction = 0;
           jump_length = x2 - hero.get_top_left_x();
           try_jump(hero, collision_box, jump_direction, jump_length);
         }
-        else if (hero_center.get_x() < x1) {
+        else if (hero_center.x < x1) {
           // fall to the west
           collision_box.set_x(x1 - 16);
           jump_direction = 4;

--- a/src/entities/Door.cpp
+++ b/src/entities/Door.cpp
@@ -505,7 +505,7 @@ void Door::update() {
   if (is_closed()
       && get_opening_method() == OPENING_BY_EXPLOSION
       && get_equipment().has_ability(ABILITY_DETECT_WEAK_WALLS)
-      && Geometry::get_distance(get_center_point().get_xy(), get_hero().get_center_point().get_xy()) < 40
+      && Geometry::get_distance(get_center_point(), get_hero().get_center_point()) < 40
       && !is_suspended()
       && System::now() >= next_hint_sound_date) {
     Sound::play("cane");

--- a/src/entities/Hero.cpp
+++ b/src/entities/Hero.cpp
@@ -765,7 +765,7 @@ void Hero::notify_map_opening_transition_finished() {
 /**
  * \copydoc MapEntity::get_facing_point
  */
-const Rectangle Hero::get_facing_point() const {
+const Point Hero::get_facing_point() const {
 
   return get_touching_point(get_animation_direction());
 }
@@ -835,9 +835,9 @@ bool Hero::is_facing_obstacle() {
  */
 bool Hero::is_facing_point_on_obstacle() {
 
-  const Rectangle& facing_point = get_facing_point();
+  const Point& facing_point = get_facing_point();
   return get_map().test_collision_with_obstacles(
-      get_layer(), facing_point.get_x(), facing_point.get_y(), *this);
+      get_layer(), facing_point, *this);
 }
 
 /**
@@ -1350,8 +1350,8 @@ bool Hero::is_ground_observer() const {
  * \brief Returns the point that determines the ground below this entity.
  * \return The point used to determine the ground (relative to the map).
  */
-const Rectangle Hero::get_ground_point() const {
-  return Rectangle(get_x(), get_y() - 2, 1, 1);
+const Point Hero::get_ground_point() const {
+  return { get_x(), get_y() };
 }
 
 /**
@@ -1939,22 +1939,22 @@ void Hero::avoid_collision(MapEntity& entity, int direction) {
 
     case 0:
       set_top_left_x(entity.get_top_left_x() + entity.get_width());
-      set_top_left_y(entity.get_center_point().get_y() - 8);
+      set_top_left_y(entity.get_center_point().y - 8);
       break;
 
     case 1:
       set_top_left_y(entity.get_top_left_y() - this->get_height());
-      set_top_left_x(entity.get_center_point().get_x() - 8);
+      set_top_left_x(entity.get_center_point().x - 8);
       break;
 
     case 2:
       set_top_left_x(entity.get_top_left_x() - this->get_width());
-      set_top_left_y(entity.get_center_point().get_y() - 8);
+      set_top_left_y(entity.get_center_point().y - 8);
       break;
 
     case 3:
       set_top_left_y(entity.get_top_left_y() + entity.get_height());
-      set_top_left_x(entity.get_center_point().get_x() - 8);
+      set_top_left_x(entity.get_center_point().x - 8);
       break;
 
     default:

--- a/src/entities/Separator.cpp
+++ b/src/entities/Separator.cpp
@@ -82,31 +82,31 @@ bool Separator::test_collision_custom(MapEntity& entity) {
   // Trigger the collision if the center point crosses the middle of the
   // separator.
 
-  const Rectangle& separator_center = get_center_point();
-  const Rectangle& center = entity.get_center_point();
+  const Point& separator_center = get_center_point();
+  const Point& center = entity.get_center_point();
 
   if (!overlaps(center)) {
     return false;
   }
 
   if (is_horizontal()) {
-    if (center.get_y() < separator_center.get_y()) {
+    if (center.y < separator_center.y) {
       // The entity is above the separator.
-      return center.get_y() == separator_center.get_y() - 1;
+      return center.y == separator_center.y - 1;
     }
     else {
       // The entity is below the separator.
-      return center.get_y() == separator_center.get_y();
+      return center.y == separator_center.y;
     }
   }
   else {
-    if (center.get_x() < separator_center.get_x()) {
+    if (center.x < separator_center.x) {
       // The entity is west of the separator.
-      return center.get_x() == separator_center.get_x() - 1;
+      return center.x == separator_center.x - 1;
     }
     else {
       // The entity is east of the separator.
-      return center.get_x() == separator_center.get_x();
+      return center.x == separator_center.x;
     }
   }
 }

--- a/src/entities/StreamAction.cpp
+++ b/src/entities/StreamAction.cpp
@@ -143,7 +143,7 @@ void StreamAction::update() {
   }
 
   // Stop the stream action if the hero escapes a non-blocking stream.
-  const Rectangle& ground_point = entity_moved->get_ground_point();
+  const Point& ground_point = entity_moved->get_ground_point();
   if (
       stream->get_allow_movement() &&
       !stream->overlaps(ground_point)  // We are no longer on the stream.

--- a/src/entities/Teletransporter.cpp
+++ b/src/entities/Teletransporter.cpp
@@ -223,9 +223,9 @@ bool Teletransporter::test_collision_custom(MapEntity& entity) {
     Hero& hero = static_cast<Hero&>(entity);
     if (is_on_map_side()) {
       // scrolling towards an adjacent map
-      const Rectangle& touching_point = hero.get_touching_point(transition_direction);
+      const Point& touching_point = hero.get_touching_point(transition_direction);
       collision = hero.is_moving_towards(transition_direction)
-          && overlaps(touching_point.get_xy());
+          && overlaps(touching_point);
       normal_case = false;
     }
 

--- a/src/hero/RunningState.cpp
+++ b/src/hero/RunningState.cpp
@@ -361,28 +361,28 @@ bool Hero::RunningState::is_cutting_with_sword(Detector& detector) {
 
   // check the distance to the detector
   const int distance = 8;
-  Rectangle tested_point = get_hero().get_facing_point();
+  Point tested_point = get_hero().get_facing_point();
 
   switch (get_sprites().get_animation_direction()) {
 
     case 0: // right
-      tested_point.add_x(distance);
+      tested_point.x += distance;
       break;
 
     case 1: // up
-      tested_point.add_y(-distance);
+      tested_point.y -= distance;
       break;
 
     case 2: // left
-      tested_point.add_x(-distance);
+      tested_point.x -= distance;
       break;
 
     case 3: // down
-      tested_point.add_y(distance);
+      tested_point.y += distance;
       break;
   }
 
-  return detector.overlaps(tested_point.get_xy());
+  return detector.overlaps(tested_point);
 }
 
 /**

--- a/src/hero/SwordSwingingState.cpp
+++ b/src/hero/SwordSwingingState.cpp
@@ -168,28 +168,28 @@ bool Hero::SwordSwingingState::is_cutting_with_sword(
 
   // check the distance to the detector
   int distance = detector.is_obstacle_for(hero) ? 14 : 4;
-  Rectangle tested_point = hero.get_facing_point();
+  Point tested_point = hero.get_facing_point();
 
   switch (get_sprites().get_animation_direction()) {
 
     case 0: // right
-      tested_point.add_x(distance);
+      tested_point.x += distance;
       break;
 
     case 1: // up
-      tested_point.add_y(-distance);
+      tested_point.y -= distance;
       break;
 
     case 2: // left
-      tested_point.add_x(-distance);
+      tested_point.x -= distance;
       break;
 
     case 3: // down
-      tested_point.add_y(distance);
+      tested_point.y += distance;
       break;
   }
 
-  return detector.overlaps(tested_point.get_xy());
+  return detector.overlaps(tested_point);
 }
 
 /**

--- a/src/hero/SwordTappingState.cpp
+++ b/src/hero/SwordTappingState.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -77,11 +77,11 @@ void Hero::SwordTappingState::update() {
   if (hero.get_movement() == nullptr) {
     // the hero is not being pushed after hitting an enemy
 
-    const Rectangle& facing_point = hero.get_facing_point();
+    const Point& facing_point = hero.get_facing_point();
 
     if (!get_commands().is_command_pressed(GameCommands::ATTACK)
         || get_commands().get_wanted_direction8() != get_sprites().get_animation_direction8()
-        || !get_map().test_collision_with_obstacles(hero.get_layer(), facing_point.get_x(), facing_point.get_y(), hero)) {
+        || !get_map().test_collision_with_obstacles(hero.get_layer(), facing_point, hero)) {
       // the sword key has been released, the player has moved or the obstacle is gone
 
       if (get_sprites().get_current_frame() >= 5) {

--- a/src/lua/EntityApi.cpp
+++ b/src/lua/EntityApi.cpp
@@ -871,9 +871,9 @@ int LuaContext::entity_api_get_center_position(lua_State* l) {
   return LuaTools::exception_boundary_handle(l, [&] {
     const MapEntity& entity = *check_entity(l, 1);
 
-    const Rectangle& center_point = entity.get_center_point();
-    lua_pushinteger(l, center_point.get_x());
-    lua_pushinteger(l, center_point.get_y());
+    const Point& center_point = entity.get_center_point();
+    lua_pushinteger(l, center_point.x);
+    lua_pushinteger(l, center_point.y);
     return 2;
   });
 }


### PR DESCRIPTION
I changed the return types of all the functions *_point so that they return a Point instead of a 1x1 Rectangle. I couldn't observe any regression, even though some functions (for example overlaps) now call their Point overload instead of their Rectangle overload.

I also added Point overloads to MapEntity's test_collision_with_border and test_collision_with_obstacles.
