### PR TITLE
Used Rectangle::get_center instead of manually computing it.

### DIFF
--- a/src/entities/MapEntity.cpp
+++ b/src/entities/MapEntity.cpp
@@ -706,7 +706,7 @@ void MapEntity::set_xy(int x, int y) {
  * \brief Sets the coordinates of the origin point of the entity, relative to the map.
  *
  * This function sets the coordinates of the point as returned by get_x() and get_y().
- * 
+ *
  * \param xy the new coordinates of the entity on the map.
  */
 void MapEntity::set_xy(const Point& xy) {
@@ -2080,12 +2080,7 @@ int MapEntity::get_distance(const MapEntity& other) const {
 int MapEntity::get_distance_to_camera() const {
 
   const Rectangle& camera = get_map().get_camera_position();
-  return (int) Geometry::get_distance(
-      get_x(),
-      get_y(),
-      camera.get_x() + camera.get_width() / 2,
-      camera.get_y() + camera.get_height() / 2
-  );
+  return (int) Geometry::get_distance(get_xy(), camera.get_center());
 }
 
 /**
@@ -2096,12 +2091,7 @@ int MapEntity::get_distance_to_camera() const {
 int MapEntity::get_distance_to_camera2() const {
 
   const Rectangle& camera = get_map().get_camera_position();
-  return Geometry::get_distance2(
-      get_x(),
-      get_y(),
-      camera.get_x() + camera.get_width() / 2,
-      camera.get_y() + camera.get_height() / 2
-  );
+  return Geometry::get_distance2(get_xy(), camera.get_center());
 }
 
 /**

--- a/src/movements/RandomMovement.cpp
+++ b/src/movements/RandomMovement.cpp
@@ -116,7 +116,7 @@ void RandomMovement::set_next_direction() {
   else {
 
     // we are outside the bounds: get back into the rectangle to avoid going too far
-    angle = Geometry::get_angle(get_x(), get_y(), bounds.get_x() + bounds.get_width() / 2, bounds.get_y() + bounds.get_height() / 2);
+    angle = Geometry::get_angle(get_xy(), bounds.get_center());
   }
   set_angle(angle);
 


### PR DESCRIPTION
There were some places in the code where the position of the center of a Rectangle was obviously manually computed. I used get_center instead to simplify the code.
