### PR TITLE
Return strings by non-const value.

### DIFF
--- a/include/SavegameConverterV1.h
+++ b/include/SavegameConverterV1.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -40,7 +40,7 @@ class SavegameConverterV1 {
     SavegameConverterV1(const std::string& file_name);
 
     // data
-    const std::string get_string(int index);
+    std::string get_string(int index);
     uint32_t get_integer(int index);
     bool get_boolean(int index);
 

--- a/include/lowlevel/FileTools.h
+++ b/include/lowlevel/FileTools.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -85,7 +85,7 @@ class FileTools {
     static const std::string& get_solarus_write_dir();
     static const std::string& get_quest_write_dir();
     static void set_quest_write_dir(const std::string& quest_write_dir);
-    static const std::string get_full_quest_write_dir();
+    static std::string get_full_quest_write_dir();
 
     // Temporary files.
     static std::string create_temporary_file(const std::string& content);

--- a/include/lowlevel/InputEvent.h
+++ b/include/lowlevel/InputEvent.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2014 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -247,7 +247,7 @@ class InputEvent {
     static InputEvent::KeyboardKey get_keyboard_key_by_name(const std::string& keyboard_key_name);
 
     bool is_character_pressed() const;
-    const std::string get_character() const;
+    std::string get_character() const;
 
     // joypad
     static bool is_joypad_enabled();
@@ -293,7 +293,7 @@ class InputEvent {
     static const KeyboardKey directional_keys[];  /**< array of the keyboard directional keys */
     static bool joypad_enabled;                   /**< true if joypad support is enabled
                                                    * (may be true even without joypad plugged) */
-    static SDL_Joystick* joystick;                /**< the joystick object if enabled and plugged */      
+    static SDL_Joystick* joystick;                /**< the joystick object if enabled and plugged */
     static int joypad_axis_state[2];              /**< keep track of the current horizontal and verticle axis states */
     static std::map<KeyboardKey, std::string>
       keyboard_key_names;                         /**< Names of all existing keyboard keys. */

--- a/include/lowlevel/Video.h
+++ b/include/lowlevel/Video.h
@@ -68,7 +68,7 @@ class Video {
     static bool is_fullscreen();
     static void set_fullscreen(bool fullscreen);
 
-    static const std::string get_window_title();
+    static std::string get_window_title();
     static void set_window_title(const std::string& window_title);
 
     static bool parse_size(const std::string& size_string, Size& size);

--- a/include/movements/PathMovement.h
+++ b/include/movements/PathMovement.h
@@ -65,7 +65,7 @@ class PathMovement: public PixelMovement {
     int get_total_distance_covered() const;
     virtual int get_displayed_direction4() const override;
 
-    static const std::string create_random_path();
+    static std::string create_random_path();
 
     virtual const std::string& get_lua_type_name() const override;
 

--- a/src/SavegameConverterV1.cpp
+++ b/src/SavegameConverterV1.cpp
@@ -51,7 +51,7 @@ SavegameConverterV1::SavegameConverterV1(const std::string& file_name) {
  * (see enum StringIndex for their definition)
  * \return the string value saved at this index
  */
-const std::string SavegameConverterV1::get_string(int index) {
+std::string SavegameConverterV1::get_string(int index) {
   return saved_data.strings[index];
 }
 

--- a/src/lowlevel/FileTools.cpp
+++ b/src/lowlevel/FileTools.cpp
@@ -424,7 +424,7 @@ void FileTools::set_quest_write_dir(const std::string& quest_write_dir) {
 /**
  * \brief Returns the absolute path of the quest write directory.
  */
-const std::string FileTools::get_full_quest_write_dir() {
+std::string FileTools::get_full_quest_write_dir() {
   return get_base_write_dir() + "/" + get_solarus_write_dir() + "/" + get_quest_write_dir();
 }
 

--- a/src/lowlevel/InputEvent.cpp
+++ b/src/lowlevel/InputEvent.cpp
@@ -741,7 +741,7 @@ bool InputEvent::is_character_pressed() const {
  * \brief Returns a UTF-8 representation of the character that was pressed during this text event.
  * \return The UTF-8 string corresponding to the entered character, or an empty string if this is not a text event.
  */
-const std::string InputEvent::get_character() const {
+std::string InputEvent::get_character() const {
 
   return internal_event.text.text;
 }

--- a/src/lowlevel/Video.cpp
+++ b/src/lowlevel/Video.cpp
@@ -634,7 +634,7 @@ void Video::render(const SurfacePtr& quest_surface) {
  * \brief Returns the current text of the window title bar.
  * \return The window title.
  */
-const std::string Video::get_window_title() {
+std::string Video::get_window_title() {
 
   return SDL_GetWindowTitle(main_window);
 }

--- a/src/movements/PathMovement.cpp
+++ b/src/movements/PathMovement.cpp
@@ -438,9 +438,9 @@ void PathMovement::set_snapping_trajectory(const Point& src, const Point& dst) {
 
 /**
  * \brief Returns a string describing a path with random length in one of the four main directions.
- * \return a random path
+ * \return A random path.
  */
-const std::string PathMovement::create_random_path() {
+std::string PathMovement::create_random_path() {
 
   char c = '0' + (Random::get_number(4) * 2);
   int length = Random::get_number(5) + 3;


### PR DESCRIPTION
Returning objects by const value inhibits move semantics. I changed functions that return std::string by const value so that they return by non-const value. I can make a difference for any class where the move operation is cheaper than the copy operation (generally strings and containers).

I have the feeling that the guideline for C++11 is "never return by const value". However, I couldn't find such a clear guideline. I chose to return non-const values at least for classes where the move operation is cheap.
