### PR TITLE
Fix bug in Crystal::activate.

### DIFF
--- a/src/entities/Crystal.cpp
+++ b/src/entities/Crystal.cpp
@@ -123,7 +123,10 @@ void Crystal::activate(MapEntity& entity_activating) {
 
   bool recently_activated = false;
   for (MapEntity* entity: entities_activating) {
-    recently_activated  = (entity == &entity_activating);
+    if (entity == &entity_activating) {
+      recently_activated = true;
+      break;
+    }
   }
 
   uint32_t now = System::now();


### PR DESCRIPTION
This fixes a regression that was introduced with the range-based for loop. I didn't want to rewrite an old iterator-based loop, and using std::any_of would have been slightly too verbose (still waiting for algorithms to take containers instead of pairs of iterators), so I finally chose a break solution.
