### PR TITLE
Improvements suggested by CppCheck.

### DIFF
--- a/src/entities/Stairs.cpp
+++ b/src/entities/Stairs.cpp
@@ -284,7 +284,7 @@ std::string Stairs::get_path(Way way) {
     std::string inverse_path = "";
     std::string::reverse_iterator it;
     int direction = 0;
-    for (it = path.rbegin(); it != path.rend(); it++) {
+    for (it = path.rbegin(); it != path.rend(); ++it) {
       direction = *it - '0';
       direction = (direction + 4) % 8;
       inverse_path += '0' + direction;

--- a/src/lowlevel/FileTools.cpp
+++ b/src/lowlevel/FileTools.cpp
@@ -299,7 +299,7 @@ std::vector<std::string> FileTools::data_files_enumerate(
 
   std::vector<std::string> result;
 
-  if (data_file_exists(dir_path.c_str())) {
+  if (data_file_exists(dir_path)) {
     char** files = PHYSFS_enumerateFiles(dir_path.c_str());
 
     for (char** file = files; *file != nullptr; file++) {

--- a/src/lowlevel/Sound.cpp
+++ b/src/lowlevel/Sound.cpp
@@ -457,7 +457,7 @@ ALuint Sound::decode_file(const std::string& file_name) {
  */
 size_t Sound::cb_read(void* ptr, size_t /* size */, size_t nb_bytes, void* datasource) {
 
-  SoundFromMemory* mem = (SoundFromMemory*) datasource;
+  SoundFromMemory* mem = static_cast<SoundFromMemory*>(datasource);
 
   const size_t total_size = mem->data.size();
   if (mem->position >= total_size) {

--- a/src/lowlevel/Surface.cpp
+++ b/src/lowlevel/Surface.cpp
@@ -58,7 +58,7 @@ class Surface::SubSurfaceNode {
         SurfacePtr src_surface,
         const Rectangle& src_rect,
         const Rectangle& dst_rect,
-        const std::vector<SubSurfaceNodePtr> subsurfaces
+        const std::vector<SubSurfaceNodePtr>& subsurfaces
     ):
       src_surface(src_surface),
       src_rect(src_rect),

--- a/src/movements/PixelMovement.cpp
+++ b/src/movements/PixelMovement.cpp
@@ -219,7 +219,7 @@ void PixelMovement::make_next_step() {
     success = true;
   }
 
-  trajectory_iterator++;
+  ++trajectory_iterator;
 
   if (trajectory_iterator == trajectory.end()) {
     if (loop) {


### PR DESCRIPTION
First set of improvements suggested by CppCheck:
- Pre-increment iterators instead of post-increment.
- Change C-style pointer cast from void\* to static_cast.
- Changed pass-by-const-value to pass-by-const-referenced (I don't know which commit changed that; it seems that the '&' disappeared without Github being notified).
- Removed a c_str that converted a std::string to const char\* to be immediately converted back to std::string.

There are more interesting suggested improvements, by I will need some guidance because they might also have downsides.
