### PR TITLE
Used an unrestricted union for FieldValue.

### DIFF
--- a/include/solarus/MapData.h
+++ b/include/solarus/MapData.h
@@ -25,9 +25,10 @@
 #include "solarus/lua/LuaData.h"
 #include <array>
 #include <map>
+#include <memory>
 #include <deque>
-#include <map>
 #include <string>
+#include <utility>
 
 namespace Solarus {
 
@@ -49,9 +50,18 @@ struct FieldValue {
     explicit FieldValue(int value);
     explicit FieldValue(bool value);
 
+    FieldValue(const FieldValue& other);
+    FieldValue(FieldValue&& other);
+
+    ~FieldValue();
+
     const EntityFieldType value_type;
-    std::string string_value;
-    int int_value;  // Also used for boolean.
+    union
+    {
+        std::string string_value;
+        int int_value;
+        bool bool_value;
+    };
 };
 
 /**

--- a/src/MapData.cpp
+++ b/src/MapData.cpp
@@ -199,25 +199,65 @@ const std::map<EntityType, EntityTypeDescription> entity_type_descriptions = {
 
 FieldValue::FieldValue(const std::string& value):
     value_type(EntityFieldType::STRING),
-    string_value(value),
-    int_value(0) {
+    string_value(value) {
 
 }
 
 FieldValue::FieldValue(int value):
     value_type(EntityFieldType::INTEGER),
-    string_value(),
     int_value(value) {
-
 
 }
 
 FieldValue::FieldValue(bool value):
     value_type(EntityFieldType::BOOLEAN),
-    string_value(),
-    int_value(value ? 1 : 0) {
+    bool_value(value) {
 
+}
 
+FieldValue::FieldValue(const FieldValue& other):
+    value_type(other.value_type) {
+
+    switch (value_type) {
+
+        case EntityFieldType::STRING:
+            new (&string_value) std::string(other.string_value);
+            break;
+
+        case EntityFieldType::INTEGER:
+            int_value = other.int_value;
+            break;
+
+        case EntityFieldType::BOOLEAN:
+            bool_value = other.bool_value;
+            break;
+    }
+}
+
+FieldValue::FieldValue(FieldValue&& other):
+    value_type(other.value_type) {
+
+    switch (value_type) {
+
+        case EntityFieldType::STRING:
+            new (&string_value) std::string(std::move(other.string_value));
+            break;
+
+        case EntityFieldType::INTEGER:
+            int_value = other.int_value;
+            break;
+
+        case EntityFieldType::BOOLEAN:
+            bool_value = other.bool_value;
+            break;
+    }
+}
+
+FieldValue::~FieldValue() {
+    using std::string;
+    if (value_type == EntityFieldType::STRING) {
+        string_value.~string();
+    }
 }
 
 


### PR DESCRIPTION
I used an union to store the possible values of FieldValue instead of having unused storage space.
From what I can see, it is an immutable class, so I didn't bother reimplementing operator= since it does not make sense for an immutable class. I also added a move constructor, just in case. Now, the class can be extended with new types/new members if desired without needlessly using more memory. It might currently seem to be a little verbose, but it's the price for having lighter and extendable class.
