### PR TITLE
Added an appdata.xml file for Linux software gallery integration

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -185,6 +185,12 @@ if(UNIX AND NOT APPLE)
     DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
 endif(UNIX AND NOT APPLE)
 
+# AppStream compatible software gallery metadata
+if(UNIX AND NOT APPLE)
+  install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/../gui/resources/solarus.appdata.xml
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/appdata)
+endif(UNIX AND NOT APPLE)
+
 # Linux Manpage
 if(UNIX AND NOT APPLE)
   install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/../solarus.6

--- a/gui/resources/solarus.appdata.xml
+++ b/gui/resources/solarus.appdata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>solarus.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>Solarus</name>
+  <summary>ARPG 2D game engine</summary>
+  <description>
+    <p>
+      Solarus is an open-source Zelda-like 2D game engine.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>http://www.solarus-games.org/wp-content/uploads/2016/07/solarus-launcher.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">http://www.solarus-games.org/</url>
+  <update_contact>christopho@solarus-games.org</update_contact>
+</component>


### PR DESCRIPTION
My goal is described in https://en.opensuse.org/openSUSE:AppStore but this works across distributions as this is based on the https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps standard.