### PR TITLE
hero:on_movement_changed hot fix. closes #1095.

### DIFF
--- a/src/entities/Hero.cpp
+++ b/src/entities/Hero.cpp
@@ -1182,6 +1182,7 @@ void Hero::notify_movement_changed() {
   if (get_ground_below() == Ground::ICE) {
     update_ice();
   }
+  Entity::notify_movement_changed();
 }
 
 /**


### PR DESCRIPTION
Calling `Entity::notify_movement_changed`  from `Hero::notify_movement_changed` to allow proper event propagation.