### PR TITLE
added backtrace printing for lua errors

### DIFF
--- a/include/solarus/lua/LuaContext.h
+++ b/include/solarus/lua/LuaContext.h
@@ -1018,8 +1018,9 @@ class LuaContext {
       // available to all userdata types
       userdata_meta_gc,
       userdata_meta_newindex_as_table,
-      userdata_meta_index_as_table;
-
+      userdata_meta_index_as_table,
+      // Lua backtrace error function
+      l_backtrace;
   private:
 
     /**

--- a/src/lua/LuaContext.cpp
+++ b/src/lua/LuaContext.cpp
@@ -2961,5 +2961,27 @@ int LuaContext::l_loader(lua_State* l) {
   });
 }
 
+/**
+ * \brief A function that prints the stack trace of an error raised in lua
+ * \param l The lua context
+ * \return Number of values to return to lua
+ */
+int LuaContext::l_backtrace(lua_State* l) {
+    if (!lua_isstring(l, 1)) return 1;
+    lua_getglobal(l, "debug");
+    if (!lua_istable(l, -1)) {
+        lua_pop(l, 1);
+        return 1;
+    }
+    lua_getfield(l, -1, "traceback");
+    if (!lua_isfunction(l, -1)) {
+        lua_pop(l, 2);
+        return 1;
+    }
+    lua_pushvalue(l, 1);    // pass error message
+    lua_call(l, 1, 1);      // call debug.traceback
+    return 1;
+}
+
 }
 

--- a/src/lua/LuaTools.cpp
+++ b/src/lua/LuaTools.cpp
@@ -18,6 +18,7 @@
 #include "solarus/lua/LuaException.h"
 #include "solarus/lua/LuaTools.h"
 #include "solarus/lua/ScopedLuaRef.h"
+#include "solarus/lua/LuaContext.h"
 #include "solarus/Map.h"
 #include <cctype>
 #include <sstream>
@@ -114,14 +115,18 @@ bool call_function(
     int nb_results,
     const char* function_name
 ) {
-  if (lua_pcall(l, nb_arguments, nb_results, 0) != 0) {
+  int base = lua_gettop(l) - nb_arguments;
+  lua_pushcfunction(l, &LuaContext::l_backtrace);
+  lua_insert(l, base);
+  int status = lua_pcall(l, nb_arguments, nb_results, base);
+  lua_remove(l,base);
+  if (status != 0) {
     Debug::error(std::string("In ") + function_name + ": "
         + lua_tostring(l, -1)
     );
     lua_pop(l, 1);
     return false;
   }
-
   return true;
 }
 


### PR DESCRIPTION
Modified the `call_function` function to print stacktrace on error. This is very handy when lua scripts tends to grow larger.