### PR TITLE
set_pixels,get_pixels for surfaces

### DIFF
--- a/include/solarus/lowlevel/Surface.h
+++ b/include/solarus/lowlevel/Surface.h
@@ -86,6 +86,8 @@ class Surface: public Drawable {
     void set_opacity(uint8_t opacity);
 
     std::string get_pixels() const;
+    void set_pixels(const std::string& buffer);
+
     void apply_pixel_filter(const SoftwarePixelFilter& pixel_filter, Surface& dst_surface);
 
     void render(SDL_Texture& render_target);

--- a/src/lua/LuaTools.cpp
+++ b/src/lua/LuaTools.cpp
@@ -486,8 +486,9 @@ std::string check_string(
             + luaL_typename(l, index) + ")"
     );
   }
-  size_t str_len = lua_strlen(l,index);
-  return {lua_tostring(l, index),str_len};
+  size_t str_len=0;
+  const char* c_str = lua_tolstring(l,index,&str_len);
+  return {c_str,str_len};
 }
 
 /**

--- a/src/lua/LuaTools.cpp
+++ b/src/lua/LuaTools.cpp
@@ -486,8 +486,8 @@ std::string check_string(
             + luaL_typename(l, index) + ")"
     );
   }
-
-  return lua_tostring(l, index);
+  size_t str_len = lua_strlen(l,index);
+  return {lua_tostring(l, index),str_len};
 }
 
 /**

--- a/src/lua/SurfaceApi.cpp
+++ b/src/lua/SurfaceApi.cpp
@@ -255,9 +255,10 @@ int LuaContext::surface_api_get_pixels(lua_State* l) {
  * \return Number of values to return to Lua.
  */
 int LuaContext::surface_api_set_pixels(lua_State* l) {
-
   return LuaTools::exception_boundary_handle(l, [&] {
-    // TODO
+    Surface& surface = *check_surface(l,1);
+    const std::string& buffer = LuaTools::check_string(l,2);
+    surface.set_pixels(buffer);
     return 0;
   });
 }


### PR DESCRIPTION
Working get_pixels, set_pixels methods for sol.surface.

Addition implied to modify LuaTools:check_string to acquire length from lua stack rater than reading up to a null-byte. This possibly implies a speedup for huge strings transfer between lua and C++. 