### PR TITLE
lua surface:set_pixels implemented, lua checkstring corrected

### DIFF
--- a/include/solarus/graphics/Surface.h
+++ b/include/solarus/graphics/Surface.h
@@ -89,7 +89,10 @@ class Surface: public Drawable {
 
     SDL_Surface* get_internal_surface();
     bool is_pixel_transparent(int index) const;
+
     std::string get_pixels() const;
+    void set_pixels(const std::string& buffer);
+
     void apply_pixel_filter(const SoftwarePixelFilter& pixel_filter, Surface& dst_surface);
 
     // Implementation from Drawable.

--- a/src/graphics/Surface.cpp
+++ b/src/graphics/Surface.cpp
@@ -291,6 +291,47 @@ std::string Surface::get_pixels() const {
 }
 
 /**
+ * @brief Set pixels of this surface from a RGBA buffer
+ * @param buffer a string considerer as array of bytes with pixels in RGBA
+ */
+void Surface::set_pixels(const std::string& buffer) {
+    const int pixels_size = get_width() * get_height() * 4;
+    const size_t buffer_size = buffer.size() > pixels_size ? pixels_size : buffer.size();
+
+    if (internal_surface->format->format == SDL_PIXELFORMAT_ABGR8888) {
+      // No conversion needed.
+      char* pixels = static_cast<char*>(internal_surface->pixels);
+      std::copy(buffer.begin(),buffer.end(),pixels);
+      return;
+    }
+    uint8_t pixels[buffer_size];
+    std::copy(buffer.begin(),buffer.end(),pixels);
+    SDL_PixelFormat* format_rgba = SDL_AllocFormat(SDL_PIXELFORMAT_ABGR8888); //TODO keep this object :)
+    SDL_Surface_UniquePtr rgba_surf(SDL_CreateRGBSurfaceFrom(
+          pixels,
+          get_width(),
+          get_height(),
+          format_rgba->BitsPerPixel,
+          format_rgba->BytesPerPixel*get_width(),
+          format_rgba->Rmask,
+          format_rgba->Gmask,
+          format_rgba->Bmask,
+          format_rgba->Amask
+      ));
+    SDL_FreeFormat(format_rgba);
+    //Convert from RGBA
+    SDL_PixelFormat* pixel_format = Video::get_pixel_format();
+    SDL_Surface_UniquePtr converted_surf(SDL_ConvertSurface(
+         rgba_surf.get(),
+         pixel_format,
+         0
+    ));
+    internal_surface = std::move(converted_surf);
+    SDL_SetSurfaceAlphaMod(internal_surface.get(), opacity);  // Re-apply the alpha.
+    SDL_SetSurfaceBlendMode(internal_surface.get(), SDL_BLENDMODE_BLEND);
+}
+
+/**
  * \brief Clears this surface.
  *
  * The surface becomes fully transparent and its size remains unchanged.

--- a/src/lua/LuaTools.cpp
+++ b/src/lua/LuaTools.cpp
@@ -492,7 +492,9 @@ std::string check_string(
     );
   }
 
-  return lua_tostring(l, index);
+  size_t str_len=0;
+  const char* c_str = lua_tolstring(l,index,&str_len);
+  return {c_str,str_len};
 }
 
 /**

--- a/src/lua/SurfaceApi.cpp
+++ b/src/lua/SurfaceApi.cpp
@@ -255,11 +255,12 @@ int LuaContext::surface_api_get_pixels(lua_State* l) {
  * \return Number of values to return to Lua.
  */
 int LuaContext::surface_api_set_pixels(lua_State* l) {
-
-  return LuaTools::exception_boundary_handle(l, [&] {
-    // TODO
-    return 0;
-  });
+    return LuaTools::exception_boundary_handle(l, [&] {
+        Surface& surface = *check_surface(l,1);
+        const std::string& buffer = LuaTools::check_string(l,2);
+        surface.set_pixels(buffer);
+        return 0;
+    });
 }
 
 }


### PR DESCRIPTION
Working get_pixels, set_pixels methods for sol.surface.

Addition implied to modify LuaTools:check_string to acquire length from lua stack rater than reading up to a null-byte. This possibly implies a speedup for huge strings transfer between lua and C++.