### PR TITLE
Shaders for drawables

### DIFF
--- a/include/solarus/graphics/Drawable.h
+++ b/include/solarus/graphics/Drawable.h
@@ -22,6 +22,7 @@
 #include "solarus/core/Size.h"
 #include "solarus/graphics/BlendMode.h"
 #include "solarus/graphics/SurfacePtr.h"
+#include "solarus/graphics/ShaderPtr.h"
 #include "solarus/lua/ExportableToLua.h"
 #include "solarus/lua/ScopedLuaRef.h"
 #include <memory>
@@ -75,6 +76,8 @@ class Drawable: public ExportableToLua {
     void draw_region(const Rectangle& region,
         const SurfacePtr& dst_surface, const Point& dst_position);
 
+    void set_shader(const ShaderPtr& shader);
+    const ShaderPtr& get_shader() const;
     /**
      * \brief Draws this object without applying dynamic effects.
      *
@@ -105,6 +108,39 @@ class Drawable: public ExportableToLua {
         Surface& dst_surface,
         const Point& dst_position
     ) = 0;
+
+    /**
+     * \brief Draws this object with the given shader
+     *
+     * Redefine this function to draw your object onto the destination
+     * surface.
+     * \param shader A valid shader to draw the object to
+     * \param dst_surface The destination surface.
+     * \param dst_position Coordinates on the destination surface.
+     */
+    virtual void shader_draw(
+        const ShaderPtr& shader,
+        Surface& dst_surface,
+        const Point& dst_position
+        ) = 0;
+
+    /**
+     * \brief Draws a subrectangle of this object with the given shader
+     *
+     * Redefine this function to draw your object onto the destination
+     * surface.
+     * \param shader A valid shader to draw the object to
+     * \param region The subrectangl  e to draw in this object.
+     * \param dst_surface The destination surface.
+     * \param dst_position Coordinates on the destination surface.
+     */
+    virtual void shader_draw_region(
+        const ShaderPtr& shader,
+        const Rectangle& region,
+        Surface& dst_surface,
+        const Point& dst_position
+        ) = 0;
+
 
     /**
      * \brief Draws a transition effect on this drawable object.
@@ -149,6 +185,7 @@ class Drawable: public ExportableToLua {
                                    * when the transition finishes */
     bool suspended;               /**< Whether this object is suspended. */
     BlendMode blend_mode;         /**< How to draw this object on a surface. */
+    ShaderPtr shader;             /**< Optional shader used to draw the surface */
 };
 
 }

--- a/include/solarus/graphics/GlArbShader.h
+++ b/include/solarus/graphics/GlArbShader.h
@@ -57,7 +57,7 @@ class GlArbShader : public Shader {
         const std::string& uniform_name, float value_1, float value_2, float value_3, float value_4) override;
     bool set_uniform_texture(const std::string& uniform_name, const SurfacePtr& value) override;
 
-    void render(const VertexArray &array, const SurfacePtr &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
+    void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
 
     std::string default_vertex_source() const override;
     std::string default_fragment_source() const override;
@@ -74,8 +74,6 @@ class GlArbShader : public Shader {
     static void set_rendering_settings();
     GLint get_uniform_location(const std::string& uniform_name) const;
 
-    void render(const SurfacePtr& surface, const Rectangle &region, const Size &dst_size, const Point &dst_position) override;
-
     GLhandleARB program;                         /**< The program which bind the vertex and fragment shader. */
     GLhandleARB vertex_shader;                   /**< The vertex shader. */
     GLhandleARB fragment_shader;                 /**< The fragment shader. */
@@ -87,7 +85,6 @@ class GlArbShader : public Shader {
     mutable std::map<std::string, TextureUniform>
         uniform_textures;                        /**< Uniform texture value of surfaces. */
     GLuint current_texture_unit = 0;
-    static VertexArray screen_quad;
 #else
 
   static bool initialize() { return false; }

--- a/include/solarus/graphics/GlArbShader.h
+++ b/include/solarus/graphics/GlArbShader.h
@@ -62,7 +62,7 @@ class GlArbShader : public Shader {
         const std::string& uniform_name, float value_1, float value_2, float value_3, float value_4) override;
     bool set_uniform_texture(const std::string& uniform_name, const SurfacePtr& value) override;
 
-    void render(const VertexArray &array, const SurfacePtr &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
+    void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
 
     std::string default_vertex_source() const override;
     std::string default_fragment_source() const override;
@@ -79,8 +79,6 @@ class GlArbShader : public Shader {
     static void set_rendering_settings();
     GLint get_uniform_location(const std::string& uniform_name) const;
 
-    void render(const SurfacePtr& surface, const Rectangle &region, const Size &dst_size, const Point &dst_position) override;
-
     GLhandleARB program;                         /**< The program which bind the vertex and fragment shader. */
     GLhandleARB vertex_shader;                   /**< The vertex shader. */
     GLhandleARB fragment_shader;                 /**< The fragment shader. */
@@ -92,7 +90,6 @@ class GlArbShader : public Shader {
     mutable std::map<std::string, TextureUniform>
         uniform_textures;                        /**< Uniform texture value of surfaces. */
     GLuint current_texture_unit = 0;
-    static VertexArray screen_quad;
 };
 
 }

--- a/include/solarus/graphics/GlShader.h
+++ b/include/solarus/graphics/GlShader.h
@@ -58,7 +58,7 @@ class GlShader : public Shader {
       const std::string& uniform_name, float value_1, float value_2, float value_3, float value_4) override;
   bool set_uniform_texture(const std::string& uniform_name, const SurfacePtr& value) override;
 
-  void render(const VertexArray &array, const SurfacePtr &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
+  void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
 
   std::string default_vertex_source() const override;
   std::string default_fragment_source() const override;
@@ -77,8 +77,6 @@ private:
   static void set_rendering_settings();
   GLint get_uniform_location(const std::string& uniform_name) const;
 
-  void render(const SurfacePtr& surface, const Rectangle &region, const Size& dst_size, const Point& dst_position) override;
-
   GLuint program;                         /**< The program which bind the vertex and fragment shader. */
   GLuint vertex_shader;                   /**< The vertex shader. */
   GLuint fragment_shader;                 /**< The fragment shader. */
@@ -90,7 +88,7 @@ private:
   mutable std::map<std::string, TextureUniform>
       uniform_textures;                        /**< Uniform texture value of surfaces. */
   GLuint current_texture_unit = 0;
-  static VertexArray screen_quad;
+
 };
 
 }

--- a/include/solarus/graphics/GlShader.h
+++ b/include/solarus/graphics/GlShader.h
@@ -55,7 +55,7 @@ class GlShader : public Shader {
       const std::string& uniform_name, float value_1, float value_2, float value_3, float value_4) override;
   bool set_uniform_texture(const std::string& uniform_name, const SurfacePtr& value) override;
 
-  void render(const VertexArray &array, const SurfacePtr &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
+  void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
 
   std::string default_vertex_source() const override;
   std::string default_fragment_source() const override;
@@ -74,8 +74,6 @@ private:
   static void set_rendering_settings();
   GLint get_uniform_location(const std::string& uniform_name) const;
 
-  void render(const SurfacePtr& surface, const Rectangle &region, const Size& dst_size, const Point& dst_position) override;
-
   GLuint program;                         /**< The program which bind the vertex and fragment shader. */
   GLuint vertex_shader;                   /**< The vertex shader. */
   GLuint fragment_shader;                 /**< The fragment shader. */
@@ -87,7 +85,7 @@ private:
   mutable std::map<std::string, TextureUniform>
       uniform_textures;                        /**< Uniform texture value of surfaces. */
   GLuint current_texture_unit = 0;
-  static VertexArray screen_quad;
+
 };
 
 }

--- a/include/solarus/graphics/Shader.h
+++ b/include/solarus/graphics/Shader.h
@@ -22,6 +22,7 @@
 #include "solarus/graphics/ShaderData.h"
 #include "solarus/graphics/SurfacePtr.h"
 #include "solarus/graphics/VertexArrayPtr.h"
+#include "solarus/graphics/BlendMode.h"
 #include "solarus/third_party/glm/mat4x4.hpp"
 #include "solarus/third_party/glm/mat3x3.hpp"
 #include "solarus/lua/ExportableToLua.h"
@@ -81,8 +82,16 @@ class Shader : public ExportableToLua {
         const std::string& uniform_name, float value_1, float value_2, float value_3, float value_4);
     virtual bool set_uniform_texture(const std::string& uniform_name, const SurfacePtr& value);
 
-    virtual void render(const SurfacePtr& surface, const Rectangle &region, const Size &dst_size, const Point &dst_position = Point());  // TODO make pure virtual
-    virtual void render(const VertexArray &array, const SurfacePtr &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3());
+    void render(const Surface &surface, const Rectangle &region, const Size &dst_size, const Point &dst_position = Point(), bool flip_y = false);
+
+    /**
+     * @brief render the given vertex array with this shader, passing the texture and matrices as uniforms
+     * @param array a vertex array
+     * @param texture a valid surface
+     * @param mvp_matrix model view projection matrix
+     * @param uv_matrix uv_matrix
+     */
+    virtual void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) = 0;
 
     const std::string& get_lua_type_name() const override;
   protected:
@@ -90,7 +99,7 @@ class Shader : public ExportableToLua {
     void set_error(const std::string& error);
     void set_data(const ShaderData& data);
     virtual void load();  // TODO make pure virtual
-
+    static VertexArray screen_quad; /**< The quad used to draw surfaces with shaders*/
   private:
 
     const std::string shader_id;  /**< The id of the shader (filename without extension). */

--- a/include/solarus/graphics/Shader.h
+++ b/include/solarus/graphics/Shader.h
@@ -22,6 +22,7 @@
 #include "solarus/graphics/ShaderData.h"
 #include "solarus/graphics/SurfacePtr.h"
 #include "solarus/graphics/VertexArrayPtr.h"
+#include "solarus/graphics/BlendMode.h"
 #include "solarus/third_party/glm/mat4x4.hpp"
 #include "solarus/third_party/glm/mat3x3.hpp"
 #include "solarus/lua/ExportableToLua.h"
@@ -75,8 +76,16 @@ class Shader : public ExportableToLua {
         const std::string& uniform_name, float value_1, float value_2, float value_3, float value_4);
     virtual bool set_uniform_texture(const std::string& uniform_name, const SurfacePtr& value);
 
-    virtual void render(const SurfacePtr& surface, const Rectangle &region, const Size &dst_size, const Point &dst_position = Point());  // TODO make pure virtual
-    virtual void render(const VertexArray &array, const SurfacePtr &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3());
+    void render(const Surface &surface, const Rectangle &region, const Size &dst_size, const Point &dst_position = Point(), bool flip_y = false);
+
+    /**
+     * @brief render the given vertex array with this shader, passing the texture and matrices as uniforms
+     * @param array a vertex array
+     * @param texture a valid surface
+     * @param mvp_matrix model view projection matrix
+     * @param uv_matrix uv_matrix
+     */
+    virtual void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) = 0;
 
     const std::string& get_lua_type_name() const override;
   protected:
@@ -84,7 +93,7 @@ class Shader : public ExportableToLua {
     void set_error(const std::string& error);
     void set_data(const ShaderData& data);
     virtual void load();  // TODO make pure virtual
-
+    static VertexArray screen_quad; /**< The quad used to draw surfaces with shaders*/
   private:
 
     const std::string shader_id;  /**< The id of the shader (filename without extension). */

--- a/include/solarus/graphics/Sprite.h
+++ b/include/solarus/graphics/Sprite.h
@@ -109,9 +109,24 @@ class Sprite: public Drawable {
 
     // update and draw
     virtual void update() override;
+    void draw_intermediate() const;
+
+    Rectangle clamp_region(const Rectangle& region) const;
+
     virtual void raw_draw(Surface& dst_surface, const Point& dst_position) override;
     virtual void raw_draw_region(const Rectangle& region,
         Surface& dst_surface, const Point& dst_position) override;
+    virtual void shader_draw(
+        const ShaderPtr& shader,
+        Surface& dst_surface,
+        const Point& dst_position
+        ) override;
+    virtual void shader_draw_region(
+        const ShaderPtr& shader,
+        const Rectangle& region,
+        Surface& dst_surface,
+        const Point& dst_position
+        ) override;
     virtual void draw_transition(Transition& transition) override;
     virtual Surface& get_transition_surface() override;
 

--- a/include/solarus/graphics/Surface.h
+++ b/include/solarus/graphics/Surface.h
@@ -24,6 +24,7 @@
 #include "solarus/graphics/SurfaceImpl.h"
 #include "solarus/graphics/SDLPtrs.h"
 
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -85,7 +86,8 @@ class Surface: public Drawable {
     uint8_t get_opacity() const;
     void set_opacity(uint8_t opacity);
 
-    SurfaceImpl& get_internal_surface();
+    SurfaceImpl &get_internal_surface();
+    const SurfaceImpl &get_internal_surface() const;
     RenderTexture &request_render();
 
     bool is_pixel_transparent(int index) const;
@@ -105,6 +107,17 @@ class Surface: public Drawable {
         Surface& dst_surface,
         const Point& dst_position
     ) override;
+    virtual void shader_draw(
+        const ShaderPtr& shader,
+        Surface& dst_surface,
+        const Point& dst_position
+        ) override;
+    virtual void shader_draw_region(
+        const ShaderPtr& shader,
+        const Rectangle& region,
+        Surface& dst_surface,
+        const Point& dst_position
+        ) override;
     virtual void draw_transition(Transition& transition) override;
     void apply_pixel_filter(
         const SoftwarePixelFilter& pixel_filter, Surface& dst_surface) const;

--- a/include/solarus/graphics/TextSurface.h
+++ b/include/solarus/graphics/TextSurface.h
@@ -108,6 +108,17 @@ class TextSurface: public Drawable {
     virtual void raw_draw(Surface& dst_surface, const Point& dst_position) override;
     virtual void raw_draw_region(const Rectangle& region,
         Surface& dst_surface, const Point& dst_position) override;
+    virtual void shader_draw(
+        const ShaderPtr& shader,
+        Surface& dst_surface,
+        const Point& dst_position
+        ) override;
+    virtual void shader_draw_region(
+        const ShaderPtr& shader,
+        const Rectangle& region,
+        Surface& dst_surface,
+        const Point& dst_position
+        ) override;
     virtual void draw_transition(Transition& transition) override;
     virtual Surface& get_transition_surface() override;
 

--- a/include/solarus/lua/LuaContext.h
+++ b/include/solarus/lua/LuaContext.h
@@ -551,6 +551,8 @@ class LuaContext {
       drawable_api_draw_region,
       drawable_api_get_blend_mode,
       drawable_api_set_blend_mode,
+      drawable_api_set_shader,
+      drawable_api_get_shader,
       drawable_api_fade_in,
       drawable_api_fade_out,
       drawable_api_get_xy,

--- a/src/core/System.cpp
+++ b/src/core/System.cpp
@@ -103,7 +103,6 @@ void System::update() {
  * \return the name of the running OS.
  */
 std::string System::get_os() {
-
   return SDL_GetPlatform();
 }
 

--- a/src/graphics/Drawable.cpp
+++ b/src/graphics/Drawable.cpp
@@ -236,8 +236,11 @@ void Drawable::draw(const SurfacePtr& dst_surface,
   if (transition != nullptr) {
     draw_transition(*transition);
   }
-
-  raw_draw(*dst_surface, dst_position + xy);
+  if(shader) {
+    shader_draw(shader,*dst_surface,dst_position);
+  } else {
+    raw_draw(*dst_surface, dst_position + xy);
+  }
 }
 
 /**
@@ -248,7 +251,6 @@ void Drawable::draw(const SurfacePtr& dst_surface,
 void Drawable::draw_region(
     const Rectangle& region,
     const SurfacePtr& dst_surface) {
-
   draw_region(region, dst_surface, Point(0, 0));
 }
 
@@ -267,8 +269,27 @@ void Drawable::draw_region(
   if (transition != nullptr) {
     draw_transition(*transition);
   }
+  if(shader) {
+    shader_draw_region(shader,region,*dst_surface,dst_position);
+  } else {
+    raw_draw_region(region, *dst_surface, dst_position + xy);
+  }
+}
 
-  raw_draw_region(region, *dst_surface, dst_position + xy);
+/**
+ * @brief set the shader used to draw this drawable
+ * @param shader, the shader, must be a valid shader or nullptr
+ */
+void Drawable::set_shader(const ShaderPtr& shader) {
+  this->shader = shader;
+}
+
+/**
+ * @brief get current shader bound to this drawable
+ * @return current shader, can be nullptr if none
+ */
+const ShaderPtr& Drawable::get_shader() const {
+  return shader;
 }
 
 /**

--- a/src/graphics/GlArbShader.cpp
+++ b/src/graphics/GlArbShader.cpp
@@ -115,8 +115,6 @@ FunctionPointerType get_proc_address_cast(void* object_ptr) {
 
 }  // Anonymous namespace
 
-VertexArray GlArbShader::screen_quad(TRIANGLES);
-
 /**
  * \brief Initializes the GL ARB shader system.
  * \return \c true if GL ARB shaders are supported.
@@ -130,7 +128,7 @@ bool GlArbShader::initialize() {
   glShadeModel(GL_SMOOTH); // Enables smooth color shading.
 
   //Init screen quad
-  screen_quad.add_quad(Rectangle(-1,-1,2,2),Rectangle(0,0,1,1),Color::white);
+  screen_quad.add_quad(Rectangle(0,0,1,1),Rectangle(0,1,1,-1),Color::white);
 
   // Initialize GL ARB functions.
   if (SDL_GL_ExtensionSupported("GL_ARB_shader_objects") &&
@@ -281,11 +279,11 @@ void GlArbShader::load() {
   uniform_locations.clear();
 
   // Create the vertex and fragment shaders.
-  vertex_shader = create_shader(GL_VERTEX_SHADER_ARB, data.get_vertex_source().c_str());
+  vertex_shader = create_shader(GL_VERTEX_SHADER_ARB, get_vertex_source().c_str());
   if (!is_valid()) {
     return;
   }
-  fragment_shader = create_shader(GL_FRAGMENT_SHADER_ARB, data.get_fragment_source().c_str());
+  fragment_shader = create_shader(GL_FRAGMENT_SHADER_ARB, get_fragment_source().c_str());
   if (!is_valid()) {
     return;
   }
@@ -350,18 +348,11 @@ GLhandleARB GlArbShader::create_shader(unsigned int type, const char* source) {
 
   return shader;
 }
-/**
- * \copydoc Shader::render
- */
-void GlArbShader::render(const SurfacePtr& surface, const Rectangle& /*region*/, const Size &/*dst_size*/, const Point &/*dst_position*/) {
-  //TODO compute mvp and uv_matrix here
-  render(screen_quad,surface);
-}
 
 /**
  * \copydoc Shader::render
  */
-void GlArbShader::render(const VertexArray& array, const SurfacePtr& texture, const glm::mat4 &mvp_matrix, const glm::mat3 &uv_matrix) {
+void GlArbShader::render(const VertexArray& array, const Surface& texture, const glm::mat4 &mvp_matrix, const glm::mat3 &uv_matrix) {
   if(array.vertex_buffer == 0) {
     //Generate vertex-buffer
     glGenBuffersARB(1,&array.vertex_buffer);
@@ -383,8 +374,6 @@ void GlArbShader::render(const VertexArray& array, const SurfacePtr& texture, co
   glUniformMatrix4fvARB(get_uniform_location(Shader::MVP_MATRIX_NAME),1,GL_FALSE,glm::value_ptr(mvp));
 
   glm::mat3 uvm = uv_matrix;
-  uvm = glm::scale(uvm,glm::vec2(1,-1));
-  uvm = glm::translate(uvm,glm::vec2(0,-1));
   glUniformMatrix3fvARB(get_uniform_location(Shader::UV_MATRIX_NAME),1,GL_FALSE,glm::value_ptr(uvm));
 
   glEnableVertexAttribArrayARB(position_location);
@@ -397,7 +386,7 @@ void GlArbShader::render(const VertexArray& array, const SurfacePtr& texture, co
   glVertexAttribPointerARB(color_location,4,GL_UNSIGNED_BYTE,GL_TRUE,sizeof(Vertex),(void*)offsetof(Vertex,color));
 
   glActiveTextureARB(GL_TEXTURE0_ARB + 0);  // Texture unit 0.
-  SDL_GL_BindTexture(texture->get_internal_surface().get_texture(), nullptr, nullptr);
+  SDL_GL_BindTexture(texture.get_internal_surface().get_texture(), nullptr, nullptr);
 
   for (const auto& kvp : uniform_textures) {
     const GLuint texture_unit = kvp.second.unit;

--- a/src/graphics/GlShader.cpp
+++ b/src/graphics/GlShader.cpp
@@ -46,9 +46,9 @@ constexpr auto DEFAULT_VERTEX =
     varying vec2 sol_vtex_coord;
     varying vec4 sol_vcolor;
     void main() {
-      gl_Position = sol_mvp_matrix * vec4(sol_vertex,0,1);
-      sol_vcolor = sol_color;
-      sol_vtex_coord = (sol_uv_matrix * vec3(sol_tex_coord,1)).xy;
+    gl_Position = sol_mvp_matrix * vec4(sol_vertex,0,1);
+    sol_vcolor = sol_color;
+    sol_vtex_coord = (sol_uv_matrix * vec3(sol_tex_coord,1)).xy;
     }
     )";
 
@@ -60,22 +60,20 @@ constexpr auto DEFAULT_FRAGMENT =
     varying vec2 sol_vtex_coord;
     varying vec4 sol_vcolor;
     void main() {
-      vec4 tex_color = texture2D(sol_texture,sol_vtex_coord);
-      gl_FragColor = tex_color*sol_vcolor;
+    vec4 tex_color = texture2D(sol_texture,sol_vtex_coord);
+    gl_FragColor = tex_color*sol_vcolor;
     }
     )";
 
 struct GlContext {
 #define SDL_PROC(ret,func,params) ret (APIENTRY* func) params;
-  #include "gles2funcs.h"
+#include "gles2funcs.h"
 #undef SDL_PROC
 };
 
 namespace {
- GlContext ctx;
+GlContext ctx;
 }
-
-VertexArray GlShader::screen_quad(TRIANGLES);
 
 /**
  * \brief Initializes the GL 2D shader system.
@@ -86,19 +84,20 @@ bool GlShader::initialize() {
 #define SDL_PROC(ret,func,params) ctx.func=func;
 #else
 #define SDL_PROC(ret,func,params) \
-    do { \
-        ctx.func = reinterpret_cast<ret(*)params>(SDL_GL_GetProcAddress(#func)); \
-        if ( ! ctx.func ) { \
-            Debug::warning(std::string("Couldn't load GLES2 function" #func)+  SDL_GetError()); \
-            return false; \
-        } \
-    } while ( 0 );
+  do { \
+  ctx.func = reinterpret_cast<ret(*)params>(SDL_GL_GetProcAddress(#func)); \
+  if ( ! ctx.func ) { \
+  Debug::warning(std::string("Couldn't load GLES2 function" #func)+  SDL_GetError()); \
+  return false; \
+} \
+} while ( 0 );
 #endif
 #include "gles2funcs.h"
 #undef SDL_PROC
 
+
   //Init screen quad
-  screen_quad.add_quad(Rectangle(-1,-1,2,2),Rectangle(0,0,1,1),Color::white);
+  screen_quad.add_quad(Rectangle(0,0,1,1),Rectangle(0,1,1,-1),Color::white);
 
   Logger::info("Using modern GL Shaders");
 
@@ -110,10 +109,10 @@ bool GlShader::initialize() {
  * \param shader_name The name of the shader to load.
  */
 GlShader::GlShader(const std::string& shader_id):
-    Shader(shader_id),
-    program(0),
-    vertex_shader(0),
-    fragment_shader(0) {
+  Shader(shader_id),
+  program(0),
+  vertex_shader(0),
+  fragment_shader(0) {
 
   GLint previous_program;
   ctx.glGetIntegerv(GL_CURRENT_PROGRAM, &previous_program);
@@ -161,7 +160,7 @@ void GlShader::load() {
 
   // Load the shader data file.
   const std::string shader_file_name =
-  "shaders/" + get_id() + ".dat";
+      "shaders/" + get_id() + ".dat";
 
   ShaderData data;
   bool success = data.import_from_quest_file(shader_file_name);
@@ -169,9 +168,11 @@ void GlShader::load() {
     return;
   }
 
+  set_data(data);
+
   // Create the vertex and fragment shaders.
-  vertex_shader = create_shader(GL_VERTEX_SHADER, data.get_vertex_source().c_str());
-  fragment_shader = create_shader(GL_FRAGMENT_SHADER, data.get_fragment_source().c_str());
+  vertex_shader = create_shader(GL_VERTEX_SHADER, get_vertex_source().c_str());
+  fragment_shader = create_shader(GL_FRAGMENT_SHADER, get_fragment_source().c_str());
 
   // Create a program object with both shaders.
   program = ctx.glCreateProgram();
@@ -236,7 +237,7 @@ GLuint GlShader::create_shader(GLenum type, const char* source) {
     if(info_len > 1) {
       char* info = (char*)malloc(sizeof(char) * info_len);
       ctx.glGetShaderInfoLog(shader, info_len, NULL, info);
-      Logger::error(std::string("Error compiling shader ") + get_id() + std::string(" :\n") + info);
+      Logger::error(std::string("Failed to compile shader ") + get_id() + std::string(" :\n") + info);
       free(info);
     }
 
@@ -257,21 +258,21 @@ void GlShader::check_gl_error() {
     std::string error;
 
     switch(gl_error) {
-      case GL_INVALID_OPERATION:
-        error="INVALID_OPERATION";
-        break;
-      case GL_INVALID_ENUM:
-        error="INVALID_ENUM";
-        break;
-      case GL_INVALID_VALUE:
-        error="INVALID_VALUE";
-        break;
-      case GL_OUT_OF_MEMORY:
-        error="OUT_OF_MEMORY";
-        break;
-      case GL_INVALID_FRAMEBUFFER_OPERATION:
-        error="INVALID_FRAMEBUFFER_OPERATION";
-        break;
+    case GL_INVALID_OPERATION:
+      error="INVALID_OPERATION";
+      break;
+    case GL_INVALID_ENUM:
+      error="INVALID_ENUM";
+      break;
+    case GL_INVALID_VALUE:
+      error="INVALID_VALUE";
+      break;
+    case GL_OUT_OF_MEMORY:
+      error="OUT_OF_MEMORY";
+      break;
+    case GL_INVALID_FRAMEBUFFER_OPERATION:
+      error="INVALID_FRAMEBUFFER_OPERATION";
+      break;
     }
 
     Logger::error(std::string("GL_") + error.c_str() + std::string(" - "));
@@ -290,28 +291,13 @@ std::string GlShader::default_fragment_source() const {
 /**
  * \copydoc Shader::render
  */
-void GlShader::render(const SurfacePtr& surface, const Rectangle &/*region*/, const Size &/*dst_size*/, const Point &/*dst_position*/) {
-  //TODO compute mvp and uv_matrix here
-  /*glm::mat4 viewport = glm::ortho(0,dst_size.width,0,dst_size.height);
-  glm::mat4 dst = glm::translate(glm::mat4(),glm::vec3(dst_position.x,dst_position.y,0));
-
-  glm::mat3 uv_scale = glm::scale(glm::mat3(),
-                                  glm::vec2(
-                                    region.get_width()/(float)surface->get_width(),
-                                    region.get_height()/(float)surface->get_height()
-                                    )
-                                  );
-  glm::mat3 uv_trans = glm::translate(glm::mat3(),glm::vec2(region.get_left(),region.get_top()));*/
-  render(screen_quad,surface);//,viewport*dst,uv_scale*uv_trans);
-}
-
-/**
- * \copydoc Shader::render
- */
-void GlShader::render(const VertexArray& array, const SurfacePtr& texture, const glm::mat4 &mvp_matrix, const glm::mat3 &uv_matrix) {
+void GlShader::render(const VertexArray& array, const Surface& texture, const glm::mat4 &mvp_matrix, const glm::mat3 &uv_matrix) {
   GLint previous_program;
   ctx.glGetIntegerv(GL_CURRENT_PROGRAM, &previous_program);
   ctx.glUseProgram(program);
+
+  ctx.glDisable(GL_CULL_FACE);
+
   if(array.vertex_buffer == 0) {
     //Generate vertex-buffer
     ctx.glGenBuffers(1,&array.vertex_buffer);
@@ -332,8 +318,6 @@ void GlShader::render(const VertexArray& array, const SurfacePtr& texture, const
   ctx.glUniformMatrix4fv(get_uniform_location(Shader::MVP_MATRIX_NAME),1,GL_FALSE,glm::value_ptr(mvp_matrix));
 
   glm::mat3 uvm = uv_matrix;
-  uvm = glm::scale(uvm,glm::vec2(1,-1));
-  uvm = glm::translate(uvm,glm::vec2(0,-1));
   ctx.glUniformMatrix3fv(get_uniform_location(Shader::UV_MATRIX_NAME),1,GL_FALSE,glm::value_ptr(uvm));
 
   ctx.glEnableVertexAttribArray(position_location);
@@ -346,7 +330,7 @@ void GlShader::render(const VertexArray& array, const SurfacePtr& texture, const
   ctx.glVertexAttribPointer(color_location,4,GL_UNSIGNED_BYTE,GL_TRUE,sizeof(Vertex),(void*)offsetof(Vertex,color));
 
   ctx.glActiveTexture(GL_TEXTURE0 + 0);  // Texture unit 0.
-  SDL_GL_BindTexture(texture->get_internal_surface().get_texture(), nullptr, nullptr);
+  SDL_GL_BindTexture(texture.get_internal_surface().get_texture(), nullptr, nullptr);
 
   for (const auto& kvp : uniform_textures) {
     const GLuint texture_unit = kvp.second.unit;

--- a/src/graphics/RenderTexture.cpp
+++ b/src/graphics/RenderTexture.cpp
@@ -1,6 +1,6 @@
 #include "solarus/graphics/RenderTexture.h"
 #include "solarus/graphics/Surface.h"
-
+#include "solarus/graphics/Shader.h"
 #include "solarus/core/Debug.h"
 
 namespace Solarus {
@@ -15,19 +15,19 @@ RenderTexture::RenderTexture(int width, int height)
 {
   auto renderer = Video::get_renderer();
   auto tex = SDL_CreateTexture(renderer,
-                                       Video::get_rgba_format()->format,
-                                       SDL_TEXTUREACCESS_TARGET,
-                                       width,height);
+                               Video::get_rgba_format()->format,
+                               SDL_TEXTUREACCESS_TARGET,
+                               width,height);
   Debug::check_assertion(tex!=nullptr,
                          std::string("Failed to create render texture : ") + SDL_GetError());
   target.reset(tex);
 
   auto format = Video::get_rgba_format();
   auto surf_ptr = SDL_CreateRGBSurface(0,
-                                    width,
-                                    height,
-                                    32,
-                                    format->Rmask,
+                                       width,
+                                       height,
+                                       32,
+                                       format->Rmask,
                                        format->Gmask,
                                        format->Bmask,
                                        format->Amask);
@@ -75,11 +75,11 @@ void RenderTexture::draw_other(const SurfaceImpl& texture, const Point& dst_posi
  */
 void RenderTexture::draw_region_other(const Rectangle& src_rect, const SurfaceImpl& texture, const Point& dst_position) {
   with_target([&](SDL_Renderer* renderer){
-   Rectangle dst_rect(dst_position,src_rect.get_size());
-   SDL_SetTextureAlphaMod(texture.get_texture(),texture.parent().get_opacity());
-   SDL_SetTextureBlendMode(texture.get_texture(),texture.parent().get_sdl_blend_mode());
-   SDL_RenderCopy(renderer,texture.get_texture(),src_rect,dst_rect);
- });
+    Rectangle dst_rect(dst_position,src_rect.get_size());
+    SDL_SetTextureAlphaMod(texture.get_texture(),texture.parent().get_opacity());
+    SDL_SetTextureBlendMode(texture.get_texture(),texture.parent().get_sdl_blend_mode());
+    SDL_RenderCopy(renderer,texture.get_texture(),src_rect,dst_rect);
+  });
 }
 
 /**

--- a/src/graphics/TextSurface.cpp
+++ b/src/graphics/TextSurface.cpp
@@ -21,6 +21,7 @@
 #include "solarus/core/Size.h"
 #include "solarus/core/System.h"
 #include "solarus/graphics/Surface.h"
+#include "solarus/graphics/Shader.h"
 #include "solarus/graphics/TextSurface.h"
 #include "solarus/graphics/Transition.h"
 #include "solarus/graphics/Video.h"
@@ -560,6 +561,28 @@ void TextSurface::raw_draw_region(const Rectangle& region,
     surface->raw_draw_region(
         region, dst_surface,
         dst_position + text_position);
+  }
+}
+
+void TextSurface::shader_draw(
+    const ShaderPtr& shader,
+    Surface& dst_surface,
+    const Point& dst_position
+    ) {
+  if (surface != nullptr) {
+    shader_draw_region(shader,Rectangle(surface->get_size()),dst_surface,dst_position);
+  }
+}
+
+void TextSurface::shader_draw_region(
+    const ShaderPtr& shader,
+    const Rectangle& region,
+    Surface& dst_surface,
+    const Point& dst_position
+    ) {
+  if (surface != nullptr) {
+    surface->set_blend_mode(get_blend_mode());
+    surface->shader_draw_region(shader,region,dst_surface,dst_position);
   }
 }
 

--- a/src/graphics/Video.cpp
+++ b/src/graphics/Video.cpp
@@ -390,7 +390,7 @@ void render(const SurfacePtr& quest_surface) {
     // OpenGL rendering with the current shader.
     SDL_SetRenderTarget(get_renderer(),nullptr);
     SDL_RenderClear(get_renderer());
-    context.current_shader->render(quest_surface,Rectangle(Point(0,0),quest_surface->get_size()),context.window_size);
+    context.current_shader->render(*quest_surface,Rectangle(quest_surface->get_size()),quest_surface->get_size(),Point(),true);
     SDL_GL_SwapWindow(Video::get_window());
   }
   else {

--- a/src/lua/DrawableApi.cpp
+++ b/src/lua/DrawableApi.cpp
@@ -205,6 +205,46 @@ int LuaContext::drawable_api_set_blend_mode(lua_State* l) {
 }
 
 /**
+ * \brief Implementation of drawable:set_shader().
+ * \param l the Lua context that is calling this function
+ * \return Number of values to return to Lua.
+ */
+int LuaContext::drawable_api_set_shader(lua_State* l) {
+  return LuaTools::exception_boundary_handle(l,[&]{
+    Drawable& drawable = *check_drawable(l,1);
+    ShaderPtr shader = nullptr;
+    if (!lua_isnil(l, 2)) {
+      if (is_shader(l, 2)) {
+        shader = check_shader(l, 2);
+      }
+      else {
+        LuaTools::type_error(l, 2, "shader or nil");
+      }
+    }
+    drawable.set_shader(shader);
+    return 0;
+  });
+}
+
+/**
+ * \brief Implementation of drawable:get_shader().
+ * \param l the Lua context that is calling this function
+ * \return Number of values to return to Lua.
+ */
+int LuaContext::drawable_api_get_shader(lua_State* l) {
+  return LuaTools::exception_boundary_handle(l,[&]{
+    const Drawable& drawable = *check_drawable(l,1);
+    const ShaderPtr& shader = drawable.get_shader();
+    if(shader) {
+      push_shader(l,*shader);
+    } else {
+      lua_pushnil(l);
+    }
+    return 1;
+  });
+}
+
+/**
  * \brief Implementation of drawable:fade_in().
  * \param l the Lua context that is calling this function
  * \return number of values to return to Lua

--- a/src/lua/SpriteApi.cpp
+++ b/src/lua/SpriteApi.cpp
@@ -61,6 +61,8 @@ void LuaContext::register_sprite_module() {
       { "draw_region", drawable_api_draw_region },
       { "get_blend_mode", drawable_api_get_blend_mode },
       { "set_blend_mode", drawable_api_set_blend_mode },
+      { "set_shader", drawable_api_set_shader},
+      { "get_shader", drawable_api_get_shader},
       { "fade_in", drawable_api_fade_in },
       { "fade_out", drawable_api_fade_out },
       { "get_xy", drawable_api_get_xy },
@@ -74,6 +76,7 @@ void LuaContext::register_sprite_module() {
         { "get_frame_src_xy", sprite_api_get_frame_src_xy }
     });
   }
+
   const std::vector<luaL_Reg> metamethods = {
       { "__gc", drawable_meta_gc },
       { "__newindex", userdata_meta_newindex_as_table },

--- a/src/lua/SurfaceApi.cpp
+++ b/src/lua/SurfaceApi.cpp
@@ -51,6 +51,8 @@ void LuaContext::register_surface_module() {
       { "draw_region", drawable_api_draw_region },
       { "get_blend_mode", drawable_api_get_blend_mode },
       { "set_blend_mode", drawable_api_set_blend_mode },
+      { "set_shader", drawable_api_set_shader},
+      { "get_shader", drawable_api_get_shader},
       { "fade_in", drawable_api_fade_in },
       { "fade_out", drawable_api_fade_out },
       { "get_xy", drawable_api_get_xy },

--- a/src/lua/TextSurfaceApi.cpp
+++ b/src/lua/TextSurfaceApi.cpp
@@ -85,6 +85,8 @@ void LuaContext::register_text_surface_module() {
       { "draw_region", drawable_api_draw_region },
       { "get_blend_mode", drawable_api_get_blend_mode },
       { "set_blend_mode", drawable_api_set_blend_mode },
+      { "set_shader", drawable_api_set_shader},
+      { "get_shader", drawable_api_get_shader},
       { "fade_in", drawable_api_fade_in },
       { "fade_out", drawable_api_fade_out },
       { "get_xy", drawable_api_get_xy },


### PR DESCRIPTION
Any drawable can now have a bound shader that will be used to draw it.

'Filters shader', those used to upscale final render on screen can now ignore the use of the uv_matrix, as it is the identity in this case.