### PR TITLE
added premultiplied alpha intermediates surfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
 
 before_script:
     # install SDL
-  - wget -q http://www.libsdl.org/release/SDL2-2.0.4.tar.gz
+  - wget -q http://www.libsdl.org/release/SDL2-2.0.6.tar.gz
   - tar xf SDL2-*.tar.gz
   - cd SDL2-* && ./configure && make && sudo make install && cd ..
 

--- a/compilation.txt
+++ b/compilation.txt
@@ -72,7 +72,7 @@ and probably with other recent compilers (please let us know).
 
 The following libraries are required to compile and execute Solarus:
 
-- SDL2 (2.0.4 or greater)
+- SDL2 (2.0.6 or greater)
 - SDL2main
 - SDL2_image
 - SDL2_ttf
@@ -91,7 +91,7 @@ snes_spc, an SPC music decoding library.
 - About SDL2:
 
 SDL 2.0.2 is buggy (you will get broken graphics or even a black screen).
-You need at least SDL 2.0.4.
+You need at least SDL 2.0.6.
 
 - About Qt5:
 

--- a/include/solarus/graphics/RenderTexture.h
+++ b/include/solarus/graphics/RenderTexture.h
@@ -47,6 +47,7 @@ public:
     ~RenderTexture(){
     }
 private:
+    SDL_BlendMode make_sdl_blend_mode(const SurfaceImpl &src) const;
     mutable bool surface_dirty = true; /**< is the surface not up to date*/
     mutable SDL_Surface_UniquePtr surface; /**< cpu side pixels data */
     mutable SDL_Texture_UniquePtr target; /**< gpu side pixels data */

--- a/include/solarus/graphics/Surface.h
+++ b/include/solarus/graphics/Surface.h
@@ -60,9 +60,9 @@ class Surface: public Drawable {
       DIR_LANGUAGE     /**< The language-specific image directory of the data package, for the current language. */
     };
 
-    Surface(int width, int height);
-    explicit Surface(SurfaceImpl* impl);
-    Surface(SDL_Surface* surf);
+    Surface(int width, int height, bool premultiplied = false);
+    explicit Surface(SurfaceImpl* impl, bool premultiplied = false);
+    Surface(SDL_Surface* surf, bool premultiplied = false);
     ~Surface();
 
     // Surfaces should only created with std::make_shared.
@@ -70,10 +70,10 @@ class Surface: public Drawable {
     // constructors.
     // This is because they are always reference-counted with shared_ptr
     // internally for drawing.
-    static SurfacePtr create(int width, int height);
-    static SurfacePtr create(const Size& size);
+    static SurfacePtr create(int width, int height, bool premultiplied = false);
+    static SurfacePtr create(const Size& size, bool premultiplied = false);
     static SurfacePtr create(const std::string& file_name,
-        ImageDirectory base_directory = DIR_SPRITES);
+        ImageDirectory base_directory = DIR_SPRITES, bool premultiplied = false);
 
     int get_width() const;
     int get_height() const;

--- a/include/solarus/graphics/SurfaceImpl.h
+++ b/include/solarus/graphics/SurfaceImpl.h
@@ -71,8 +71,12 @@ public:
      * @return valid render texture
      */
     virtual  RenderTexture* to_render_texture() = 0;
+
+    bool is_premultiplied() const;
+    void set_premultiplied(bool a_premultiplied);
 private:
     Surface* _parent; /**< pointer to owning surface */
+    bool premultiplied = false;
 };
 
 }

--- a/src/core/Map.cpp
+++ b/src/core/Map.cpp
@@ -581,7 +581,6 @@ void Map::build_background_surface() {
  * \param dst_surface The surface where to draw.
  */
 void Map::draw_background(const SurfacePtr& dst_surface) {
-
   background_surface->draw(dst_surface);
 }
 

--- a/src/entities/NonAnimatedRegions.cpp
+++ b/src/entities/NonAnimatedRegions.cpp
@@ -238,7 +238,7 @@ void NonAnimatedRegions::build_cell(int cell_index) {
       row * cell_size.height
   };
 
-  SurfacePtr cell_surface = Surface::create(cell_size,layer > map.get_min_layer());
+  SurfacePtr cell_surface = Surface::create(cell_size,true);
   optimized_tiles_surfaces[cell_index] = cell_surface;
   // Let this surface as a software destination because it is built only
   // once (here) and never changes later.

--- a/src/entities/NonAnimatedRegions.cpp
+++ b/src/entities/NonAnimatedRegions.cpp
@@ -238,7 +238,7 @@ void NonAnimatedRegions::build_cell(int cell_index) {
       row * cell_size.height
   };
 
-  SurfacePtr cell_surface = Surface::create(cell_size);
+  SurfacePtr cell_surface = Surface::create(cell_size,layer > map.get_min_layer());
   optimized_tiles_surfaces[cell_index] = cell_surface;
   // Let this surface as a software destination because it is built only
   // once (here) and never changes later.

--- a/src/graphics/Sprite.cpp
+++ b/src/graphics/Sprite.cpp
@@ -964,7 +964,7 @@ Surface& Sprite::get_transition_surface() {
 Surface& Sprite::get_intermediate_surface() const {
 
   if (intermediate_surface == nullptr) {
-    intermediate_surface = Surface::create(get_max_size());
+    intermediate_surface = Surface::create(get_max_size(),true);
   }
   return *intermediate_surface;
 }

--- a/src/graphics/Surface.cpp
+++ b/src/graphics/Surface.cpp
@@ -42,7 +42,7 @@ namespace Solarus {
  * \param width The width in pixels.
  * \param height The height in pixels.
  */
-Surface::Surface(int width, int height):
+Surface::Surface(int width, int height, bool premultiplied):
   Drawable(),
   opacity(255),
   internal_surface(nullptr)
@@ -52,13 +52,15 @@ Surface::Surface(int width, int height):
                          "Attempt to create a surface with an empty size");
 
   internal_surface.reset(new RenderTexture(width,height));
+  internal_surface->set_premultiplied(premultiplied);
   internal_surface->_parent = this;
 }
 
-Surface::Surface(SDL_Surface *surf)
+Surface::Surface(SDL_Surface *surf, bool premultiplied)
   : opacity(255),
     internal_surface(new Texture(surf))
 {
+  internal_surface->set_premultiplied(premultiplied);
   internal_surface->_parent = this;
 }
 
@@ -71,11 +73,12 @@ Surface::Surface(SDL_Surface *surf)
  * \param internal_surface The internal surface data.
  * The created surface takes ownership of this object.
  */
-Surface::Surface(SurfaceImpl* impl):
+Surface::Surface(SurfaceImpl* impl, bool premultiplied):
   Drawable(),
   opacity(255),
   internal_surface(impl) //TODO refactor this...
 {
+  internal_surface->set_premultiplied(premultiplied);
   internal_surface->_parent = this;
 }
 
@@ -96,8 +99,8 @@ Surface::~Surface() {
  * \param height The height in pixels.
  * \return The created surface.
  */
-SurfacePtr Surface::create(int width, int height) {
-  SurfacePtr surface = std::make_shared<Surface>(width, height);
+SurfacePtr Surface::create(int width, int height, bool premultiplied) {
+  SurfacePtr surface = std::make_shared<Surface>(width, height, premultiplied);
   return surface;
 }
 
@@ -106,8 +109,8 @@ SurfacePtr Surface::create(int width, int height) {
  * \param size The size in pixels.
  * \return The created surface.
  */
-SurfacePtr Surface::create(const Size& size) {
-  SurfacePtr surface = std::make_shared<Surface>(size.width, size.height);
+SurfacePtr Surface::create(const Size& size,bool premultiplied) {
+  SurfacePtr surface = std::make_shared<Surface>(size.width, size.height, premultiplied);
   return surface;
 }
 
@@ -122,7 +125,7 @@ SurfacePtr Surface::create(const Size& size) {
  * \return The surface created, or nullptr if the file could not be loaded.
  */
 SurfacePtr Surface::create(const std::string& file_name,
-                           ImageDirectory base_directory) {
+                           ImageDirectory base_directory, bool premultiplied) {
 
   SurfaceImpl* surface = get_surface_from_file(file_name, base_directory);
 
@@ -130,7 +133,7 @@ SurfacePtr Surface::create(const std::string& file_name,
     return nullptr;
   }
 
-  return std::make_shared<Surface>(surface);
+  return std::make_shared<Surface>(surface, premultiplied);
 }
 
 /**

--- a/src/graphics/SurfaceImpl.cpp
+++ b/src/graphics/SurfaceImpl.cpp
@@ -20,4 +20,18 @@ SurfaceImpl::~SurfaceImpl() {
 
 }
 
+/**
+ * @brief is_premultiplied
+ * @return
+ */
+bool SurfaceImpl::is_premultiplied() const {
+  return premultiplied;
+}
+
+/**
+ * @brief set_premultiplied
+ */
+void SurfaceImpl::set_premultiplied(bool a_premultiplied) {
+  premultiplied = a_premultiplied;
+}
 }


### PR DESCRIPTION
This fixes issue #935. A new surface property "premultiplied" has been added to keep track of the alpha blend techniques used and adapt blending modes accordingly.

Before:
![image](https://user-images.githubusercontent.com/5902491/39439303-74e86a78-4ca7-11e8-862e-0a65a0c5d0bc.png)
After:
![image](https://user-images.githubusercontent.com/5902491/39439356-97048272-4ca7-11e8-88a4-7ba8d3a82e5b.png)

I don't know if we should expose this surface property to lua. But probably not.