### PR TITLE
Intermediate surfaces removal, draw code cleaning.

### DIFF
--- a/cmake/AddCompilationFlags.cmake
+++ b/cmake/AddCompilationFlags.cmake
@@ -22,7 +22,7 @@ endif()
 # Warnings and errors.
 
 # Be less pedantic in release builds for users.
-set(CMAKE_CXX_FLAGS_RELEASE "-Wno-error -Wall -Wextra -Wno-unknown-pragmas -Wno-fatal-errors -O3 ${CMAKE_CXX_FLAGS_RELEASE}")
+set(CMAKE_CXX_FLAGS_RELEASE "-Wno-error -Wall -Wextra -Wno-unknown-pragmas -Wno-fatal-errors ${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
 # Be more pedantic in debug mode for developers.
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wextra -pedantic ${CMAKE_CXX_FLAGS_DEBUG}")

--- a/cmake/AddCompilationFlags.cmake
+++ b/cmake/AddCompilationFlags.cmake
@@ -22,7 +22,7 @@ endif()
 # Warnings and errors.
 
 # Be less pedantic in release builds for users.
-set(CMAKE_CXX_FLAGS_RELEASE "-Wno-error -Wall -Wextra -Wno-unknown-pragmas -Wno-fatal-errors ${CMAKE_CXX_FLAGS_RELEASE}")
+set(CMAKE_CXX_FLAGS_RELEASE "-Wno-error -Wall -Wextra -Wno-unknown-pragmas -Wno-fatal-errors -O3 ${CMAKE_CXX_FLAGS_RELEASE}")
 
 # Be more pedantic in debug mode for developers.
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wextra -pedantic ${CMAKE_CXX_FLAGS_DEBUG}")

--- a/cmake/AddSolarusLibrary.cmake
+++ b/cmake/AddSolarusLibrary.cmake
@@ -130,6 +130,7 @@ file(
 	include/solarus/graphics/Color.h
 	include/solarus/graphics/Drawable.h
 	include/solarus/graphics/DrawablePtr.h
+        include/solarus/graphics/DrawProxies.h
 	include/solarus/graphics/GlArbShader.h
 	include/solarus/graphics/GlShader.h
 	include/solarus/graphics/GlTextureHandle.h

--- a/include/solarus/graphics/DrawProxies.h
+++ b/include/solarus/graphics/DrawProxies.h
@@ -12,20 +12,20 @@ struct DrawProxy;
 
 struct DrawInfos {
   //Replace params proxy
-  DrawInfos(const Rectangle& region,const Point& dst_position,
+  constexpr DrawInfos(const Rectangle& region,const Point& dst_position,
             BlendMode blend_mode, uint8_t opacity,
             const DrawProxy& proxy):
     region(region),dst_position(dst_position),
     blend_mode(blend_mode), opacity(opacity),
     proxy(proxy) {}
-  DrawInfos(const DrawInfos& other, const DrawProxy& proxy) :
+  constexpr DrawInfos(const DrawInfos& other, const DrawProxy& proxy) :
     DrawInfos(other.region,other.dst_position,other.blend_mode,other.opacity,proxy) {}
-  DrawInfos(const DrawInfos &other, const Rectangle& region,
+  constexpr DrawInfos(const DrawInfos &other, const Rectangle& region,
             const Point& dst_position) :
     DrawInfos(region,dst_position,other.blend_mode,other.opacity,other.proxy) {}
-  DrawInfos(const DrawInfos &other, const Point& dst_position) :
+  constexpr DrawInfos(const DrawInfos &other, const Point& dst_position) :
     DrawInfos(other.region,dst_position,other.blend_mode,other.opacity,other.proxy) {}
-  DrawInfos(const DrawInfos& other,uint8_t opacity):
+  constexpr DrawInfos(const DrawInfos& other,uint8_t opacity):
     DrawInfos(other.region,other.dst_position,other.blend_mode,opacity,other.proxy) {}
   //TODO more helper constructors
   const Rectangle& region;
@@ -46,8 +46,7 @@ struct DrawProxy {
 template<std::size_t N>
 struct DrawProxyChain : DrawProxy {
   using Proxies = std::array<std::reference_wrapper<const DrawProxy>,N>;
-  DrawProxyChain(const Proxies& proxies) : proxies(proxies) {
-    assert(proxies.size() > 0);
+  constexpr DrawProxyChain(const Proxies& proxies) : proxies(proxies) {
   }
 
   void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override {
@@ -55,7 +54,7 @@ struct DrawProxyChain : DrawProxy {
   }
 private:
   struct Link : DrawProxy {
-    Link(const DrawProxyChain& pipeline, size_t index) :
+    constexpr Link(const DrawProxyChain& pipeline, size_t index) :
       pipeline(pipeline), index(index) {}
     void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override {
       //if(index < pipeline.proxies.size())

--- a/include/solarus/graphics/DrawProxies.h
+++ b/include/solarus/graphics/DrawProxies.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "solarus/graphics/SurfacePtr.h"
+#include "solarus/core/Rectangle.h"
+#include "solarus/graphics/BlendMode.h"
+
+#include <array>
+
+namespace Solarus {
+
+struct DrawProxy;
+
+struct DrawInfos {
+  //Replace params proxy
+  DrawInfos(const Rectangle& region,const Point& dst_position,
+            BlendMode blend_mode, uint8_t opacity,
+            const DrawProxy& proxy):
+    region(region),dst_position(dst_position),
+    blend_mode(blend_mode), opacity(opacity),
+    proxy(proxy) {}
+  DrawInfos(const DrawInfos& other, const DrawProxy& proxy) :
+    DrawInfos(other.region,other.dst_position,other.blend_mode,other.opacity,proxy) {}
+  DrawInfos(const DrawInfos &other, const Rectangle& region,
+            const Point& dst_position) :
+    DrawInfos(region,dst_position,other.blend_mode,other.opacity,other.proxy) {}
+  DrawInfos(const DrawInfos &other, const Point& dst_position) :
+    DrawInfos(other.region,dst_position,other.blend_mode,other.opacity,other.proxy) {}
+  DrawInfos(const DrawInfos& other,uint8_t opacity):
+    DrawInfos(other.region,other.dst_position,other.blend_mode,opacity,other.proxy) {}
+  //TODO more helper constructors
+  const Rectangle& region;
+  const Point& dst_position;
+  BlendMode blend_mode;
+  uint8_t   opacity;
+  const DrawProxy& proxy;
+};
+
+/**
+ * @brief The DrawProxy is used to draw with various modifiers
+ */
+struct DrawProxy {
+  virtual void draw(Surface& dst_surface, const Surface& src_surface,const DrawInfos& params) const = 0;
+  virtual bool is_terminal() const {return false;}
+};
+
+template<std::size_t N>
+struct DrawProxyChain : DrawProxy {
+  using Proxies = std::array<std::reference_wrapper<const DrawProxy>,N>;
+  DrawProxyChain(const Proxies& proxies) : proxies(proxies) {
+    assert(proxies.size() > 0);
+  }
+
+  void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override {
+    proxies.front().get().draw(dst_surface,src_surface,DrawInfos(params,Link{*this,1}));
+  }
+private:
+  struct Link : DrawProxy {
+    Link(const DrawProxyChain& pipeline, size_t index) :
+      pipeline(pipeline), index(index) {}
+    void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override {
+      //if(index < pipeline.proxies.size())
+        pipeline.proxies.at(index).get().draw(dst_surface,src_surface,DrawInfos(params,Link{pipeline,index+1}));
+      //else
+        //params.proxy.draw(dst_surface,src_surface,params); //TODO check if this happen... should not
+    }
+  private:
+    const DrawProxyChain& pipeline;
+    size_t index;
+  };
+  const Proxies& proxies;
+};
+
+template<std::size_t N>
+DrawProxyChain<N> create_draw_pipeline(const std::array<DrawProxy,N>& proxies) {
+  return DrawProxyChain<N>(proxies);
+}
+
+}
+// DRAWPROXIES_H

--- a/include/solarus/graphics/DrawProxies.h
+++ b/include/solarus/graphics/DrawProxies.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "solarus/graphics/SurfacePtr.h"
+#include "solarus/core/Rectangle.h"
+#include "solarus/graphics/BlendMode.h"
+
+#include <array>
+
+namespace Solarus {
+
+struct DrawProxy;
+
+struct DrawInfos {
+  //Replace params proxy
+  DrawInfos(const Rectangle& region,const Point& dst_position,
+            BlendMode blend_mode, uint8_t opacity,
+            const DrawProxy& proxy):
+    region(region),dst_position(dst_position),
+    blend_mode(blend_mode), opacity(opacity),
+    proxy(proxy) {}
+  DrawInfos(const DrawInfos& other, const DrawProxy& proxy) :
+    DrawInfos(other.region,other.dst_position,other.blend_mode,other.opacity,proxy) {}
+  //TODO more helper constructors
+  const Rectangle& region;
+  const Point& dst_position;
+  BlendMode blend_mode;
+  uint8_t   opacity;
+  const DrawProxy& proxy;
+};
+
+/**
+ * @brief The DrawProxy is used to draw with various modifiers
+ */
+struct DrawProxy {
+  virtual void draw(Surface& dst_surface, Surface& src_surface,const DrawInfos& params) const = 0;
+  virtual bool is_terminal() const {return false;}
+};
+
+template<std::size_t N>
+struct DrawProxyPipeline {
+  DrawProxyPipeline(const std::array<DrawProxy,N>& proxies) : proxies(proxies) {
+    assert(proxies.size() > 0);
+    assert(proxies.back().is_terminal()); //Make sure last proxy is terminal
+  }
+
+  void draw(Surface& dst_surface, Surface& src_surface, const DrawInfos& params) const override {
+    proxies.front().draw(dst_surface,src_surface,DrawInfos(params,PipeProxy{*this,1}));
+  }
+private:
+  struct PipeProxy {
+    const DrawProxyPipeline& pipeline;
+    size_t index;
+    void draw(Surface& dst_surface, Surface& src_surface, const DrawInfos& params) const override {
+      if(index < pipeline.proxies.size())
+        pipeline.proxies.at(index).draw(dst_surface,src_surface,DrawInfos(params,PipeProxy{pipeline,index+1}));
+      else
+        params.proxy.draw(dst_surface,src_surface,params); //TODO check if this happen... should not
+    }
+  };
+  const std::array<DrawProxy,N>& proxies;
+};
+
+}
+// DRAWPROXIES_H

--- a/include/solarus/graphics/DrawProxies.h
+++ b/include/solarus/graphics/DrawProxies.h
@@ -10,58 +10,86 @@ namespace Solarus {
 
 struct DrawProxy;
 
+/**
+ * @brief Struct used to pass drawing arguments trough the drawing pipeline
+ *
+ * It contains all the information needed to perform a draw of a drawable to another,
+ * it could be updated in the future to support more parameters, such as rotation and scale
+ */
 struct DrawInfos {
-  //Replace params proxy
-  DrawInfos(const Rectangle& region,const Point& dst_position,
+  inline constexpr DrawInfos(const Rectangle& region,const Point& dst_position,
             BlendMode blend_mode, uint8_t opacity,
             const DrawProxy& proxy):
     region(region),dst_position(dst_position),
     blend_mode(blend_mode), opacity(opacity),
     proxy(proxy) {}
-  DrawInfos(const DrawInfos& other, const DrawProxy& proxy) :
+  inline constexpr DrawInfos(const DrawInfos& other, const DrawProxy& proxy) :
     DrawInfos(other.region,other.dst_position,other.blend_mode,other.opacity,proxy) {}
-  DrawInfos(const DrawInfos &other, const Rectangle& region,
+  inline constexpr DrawInfos(const DrawInfos &other, const Rectangle& region,
             const Point& dst_position) :
     DrawInfos(region,dst_position,other.blend_mode,other.opacity,other.proxy) {}
-  DrawInfos(const DrawInfos &other, const Point& dst_position) :
+  inline constexpr DrawInfos(const DrawInfos &other, const Point& dst_position) :
     DrawInfos(other.region,dst_position,other.blend_mode,other.opacity,other.proxy) {}
-  DrawInfos(const DrawInfos& other,uint8_t opacity):
+  inline constexpr DrawInfos(const DrawInfos& other,uint8_t opacity):
     DrawInfos(other.region,other.dst_position,other.blend_mode,opacity,other.proxy) {}
   //TODO more helper constructors
-  const Rectangle& region;
-  const Point& dst_position;
-  BlendMode blend_mode;
-  uint8_t   opacity;
-  const DrawProxy& proxy;
+  const Rectangle& region; /**< The region of the source surface that will be drawn*/
+  const Point& dst_position; /**< The position in the target surface where the surface will be drawn */
+  BlendMode blend_mode; /**< blend mode that will be used */
+  uint8_t   opacity; /**< opacity modulator */
+  const DrawProxy& proxy; /**< proxy that drawer should use when drawing */
 };
 
 /**
  * @brief The DrawProxy is used to draw with various modifiers
+ *
+ * This interface is usefull to pass draw technique down the drawing calls, specifically
+ * in Sprite where with calls up to SpriteAnimationDirection, the DrawProxies receive
+ * draw information bundled in Drawinfos and use them to perform final drawing
  */
 struct DrawProxy {
+  /**
+   * @brief draw src_surface to dst_surface using given draw infos, potentially modifying the infos
+   * @param dst_surface the target surface that will be written to
+   * @param src_surface the src surface that will be read
+   * @param params draw parameters packed into a DrawInfos struct
+   *
+   * The proxy field of the DrawInfos struct represent the next proxy to be applied, the proxies that
+   * don't use this parameters are called 'terminals' as they terminate the draw operation. As I write
+   * It's either a surface draw or a shader draw.
+   */
   virtual void draw(Surface& dst_surface, const Surface& src_surface,const DrawInfos& params) const = 0;
-  virtual bool is_terminal() const {return false;}
 };
 
+
+
 template<std::size_t N>
+/**
+ * @brief Defines a chain of proxies to be applied
+ *
+ * Used to chain various draw proxies together, in most cases, proxies.back should be a
+ * terminal
+ */
 struct DrawProxyChain : DrawProxy {
   using Proxies = std::array<std::reference_wrapper<const DrawProxy>,N>;
-  DrawProxyChain(const Proxies& proxies) : proxies(proxies) {
-    assert(proxies.size() > 0);
+  inline constexpr DrawProxyChain(const Proxies& proxies) : proxies(proxies) {
   }
 
-  void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override {
+  /**
+   * \copydoc DrawProxy::draw
+   */
+  inline void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override {
     proxies.front().get().draw(dst_surface,src_surface,DrawInfos(params,Link{*this,1}));
   }
 private:
+  /**
+   * @brief DrawProxyChain link, that goes trough the array of proxies
+   */
   struct Link : DrawProxy {
-    Link(const DrawProxyChain& pipeline, size_t index) :
+    inline constexpr Link(const DrawProxyChain& pipeline, size_t index) :
       pipeline(pipeline), index(index) {}
-    void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override {
-      //if(index < pipeline.proxies.size())
+    inline void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override {
         pipeline.proxies.at(index).get().draw(dst_surface,src_surface,DrawInfos(params,Link{pipeline,index+1}));
-      //else
-        //params.proxy.draw(dst_surface,src_surface,params); //TODO check if this happen... should not
     }
   private:
     const DrawProxyChain& pipeline;
@@ -69,11 +97,6 @@ private:
   };
   const Proxies& proxies;
 };
-
-template<std::size_t N>
-DrawProxyChain<N> create_draw_pipeline(const std::array<DrawProxy,N>& proxies) {
-  return DrawProxyChain<N>(proxies);
-}
 
 }
 // DRAWPROXIES_H

--- a/include/solarus/graphics/Drawable.h
+++ b/include/solarus/graphics/Drawable.h
@@ -25,6 +25,7 @@
 #include "solarus/graphics/ShaderPtr.h"
 #include "solarus/lua/ExportableToLua.h"
 #include "solarus/lua/ScopedLuaRef.h"
+#include "solarus/graphics/DrawProxies.h"
 #include <memory>
 
 namespace Solarus {
@@ -42,13 +43,6 @@ class Rectangle;
 class Drawable: public ExportableToLua {
 
   public:
-
-    /**
-     * @brief The DrawProxy is used to draw with various modifiers
-     */
-    struct DrawProxy {
-      virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const = 0;
-    };
 
     virtual ~Drawable();
 

--- a/include/solarus/graphics/Drawable.h
+++ b/include/solarus/graphics/Drawable.h
@@ -25,6 +25,7 @@
 #include "solarus/graphics/ShaderPtr.h"
 #include "solarus/lua/ExportableToLua.h"
 #include "solarus/lua/ScopedLuaRef.h"
+#include "solarus/graphics/DrawProxies.h"
 #include <memory>
 
 namespace Solarus {
@@ -42,13 +43,6 @@ class Rectangle;
 class Drawable: public ExportableToLua {
 
   public:
-
-    /**
-     * @brief The DrawProxy is used to draw with various modifiers
-     */
-    struct DrawProxy {
-      virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const = 0;
-    };
 
     virtual ~Drawable();
 
@@ -82,9 +76,12 @@ class Drawable: public ExportableToLua {
     void draw_region(const Rectangle& region, const SurfacePtr& dst_surface);
     void draw_region(const Rectangle& region,
         const SurfacePtr& dst_surface, const Point& dst_position);
+    void draw_region(const Rectangle& region,
+                     const SurfacePtr& dst_surface, const Point& dst_position, const DrawProxy& proxy);
 
     void set_shader(const ShaderPtr& shader);
     const ShaderPtr& get_shader() const;
+
     /**
      * \brief Draws this object without applying dynamic effects.
      *
@@ -96,79 +93,8 @@ class Drawable: public ExportableToLua {
      */
     virtual void raw_draw(
         Surface& dst_surface,
-        const Point& dst_position,
-        const DrawProxy& proxy
-    ) = 0;
-
-    /**
-     * \brief Draws a subrectangle of this object without applying dynamic
-     * effects.
-     *
-     * Redefine this function to draw your object onto the destination
-     * surface.
-     *
-     * \param region The subrectangle to draw in this object.
-     * \param dst_surface The destination surface.
-     * \param dst_position Coordinates on the destination surface.
-     */
-    virtual void raw_draw_region(
-        const Rectangle& region,
-        Surface& dst_surface,
-        const Point& dst_position,
-        const DrawProxy& proxy
-    ) = 0;
-
-    /**
-     * \brief Draws this object with the given shader
-     *
-     * Redefine this function to draw your object onto the destination
-     * surface.
-     * \param shader A valid shader to draw the object to
-     * \param dst_surface The destination surface.
-     * \param dst_position Coordinates on the destination surface.
-     */
-    virtual void shader_draw(
-        const ShaderPtr& shader,
-        Surface& dst_surface,
-        const Point& dst_position
-        ) = 0;
-
-    /**
-     * \brief Draws a subrectangle of this object with the given shader
-     *
-     * Redefine this function to draw your object onto the destination
-     * surface.
-     * \param shader A valid shader to draw the object to
-     * \param region The subrectangl  e to draw in this object.
-     * \param dst_surface The destination surface.
-     * \param dst_position Coordinates on the destination surface.
-     */
-    virtual void shader_draw_region(
-        const ShaderPtr& shader,
-        const Rectangle& region,
-        Surface& dst_surface,
-        const Point& dst_position
-        ) = 0;
-
-
-    /**
-     * \brief Draws a transition effect on this drawable object.
-     *
-     * Redefine this function to apply the transition effect on the surface
-     * of your object.
-     *
-     * \param transition The transition effect to apply.
-     *
-     * TODO Since there is get_transition_surface() now, this function can probably be removed.
-     */
-    //virtual void draw_transition(Transition& transition) = 0;
-
-    /**
-     * \brief Returns the surface where transitions on this drawable object
-     * are applied.
-     * \return The surface for transitions.
-     */
-    //virtual Surface& get_transition_surface() = 0;
+        const DrawInfos& infos
+    ) const = 0;
 
     virtual void update();
     bool is_suspended() const;
@@ -177,11 +103,14 @@ class Drawable: public ExportableToLua {
     BlendMode get_blend_mode() const;
     void set_blend_mode(BlendMode blend_mode);
 
+    uint8_t get_opacity() const;
+    void set_opacity(uint8_t opacity);
+
+    virtual Rectangle get_region() const = 0;
   protected:
-
     Drawable();
-
   private:
+    const DrawProxy& terminal() const;
 
     Point xy;                     /**< Current position of this object
                                    * (result of movements). */
@@ -194,7 +123,8 @@ class Drawable: public ExportableToLua {
                                    * when the transition finishes */
     bool suspended;               /**< Whether this object is suspended. */
     BlendMode blend_mode;         /**< How to draw this object on a surface. */
-    ShaderPtr shader;             /**< Optional shader used to draw the surface */
+    ShaderPtr shader;             /**< Optional shader used to draw the object */
+    uint8_t opacity = 255;              /**< Opacity of this drawable object */
 };
 
 }

--- a/include/solarus/graphics/Drawable.h
+++ b/include/solarus/graphics/Drawable.h
@@ -69,29 +69,44 @@ class Drawable: public ExportableToLua {
     Transition* get_transition();
 
     // drawing with effects
-
-    void draw(const SurfacePtr& dst_surface);
-    void draw(const SurfacePtr& dst_surface, int x, int y);
-    void draw(const SurfacePtr& dst_surface, const Point& dst_position);
-    void draw_region(const Rectangle& region, const SurfacePtr& dst_surface);
+    void draw(const SurfacePtr& dst_surface) const;
+    void draw(const SurfacePtr& dst_surface, int x, int y) const;
+    void draw(const SurfacePtr& dst_surface, const Point& dst_position) const;
+    void draw(const SurfacePtr &dst_surface, const Point &dst_position, const DrawProxy& proxy) const;
+    void draw_region(const Rectangle& region, const SurfacePtr& dst_surface) const;
     void draw_region(const Rectangle& region,
-        const SurfacePtr& dst_surface, const Point& dst_position);
+        const SurfacePtr& dst_surface, const Point& dst_position) const;
     void draw_region(const Rectangle& region,
-                     const SurfacePtr& dst_surface, const Point& dst_position, const DrawProxy& proxy);
+                     const SurfacePtr& dst_surface, const Point& dst_position, const DrawProxy& proxy) const;
 
     void set_shader(const ShaderPtr& shader);
     const ShaderPtr& get_shader() const;
 
     /**
-     * \brief Draws this object without applying dynamic effects.
+     * \brief Draws this object with effect information passed
      *
      * Redefine this function to draw your object onto the destination
      * surface.
      *
+     * This version may ignore the passed infos.region parameter and draw
+     * at full size, this allow sprites to optimize drawing when no cropping
+     * is needed, as it is often the case
+     *
      * \param dst_surface The destination surface.
-     * \param dst_position Coordinates on the destination surface.
+     * \param infos draw informations bundle
      */
     virtual void raw_draw(
+        Surface& dst_surface,
+        const DrawInfos& infos
+    ) const = 0;
+
+    /**
+     * @brief Draw
+     *
+     * @param dst_surface
+     * @param infos draw information bundle
+     */
+    virtual void raw_draw_region(
         Surface& dst_surface,
         const DrawInfos& infos
     ) const = 0;

--- a/include/solarus/graphics/Drawable.h
+++ b/include/solarus/graphics/Drawable.h
@@ -43,6 +43,13 @@ class Drawable: public ExportableToLua {
 
   public:
 
+    /**
+     * @brief The DrawProxy is used to draw with various modifiers
+     */
+    struct DrawProxy {
+      virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const = 0;
+    };
+
     virtual ~Drawable();
 
     virtual Point get_origin() const;
@@ -89,7 +96,8 @@ class Drawable: public ExportableToLua {
      */
     virtual void raw_draw(
         Surface& dst_surface,
-        const Point& dst_position
+        const Point& dst_position,
+        const DrawProxy& proxy
     ) = 0;
 
     /**
@@ -106,7 +114,8 @@ class Drawable: public ExportableToLua {
     virtual void raw_draw_region(
         const Rectangle& region,
         Surface& dst_surface,
-        const Point& dst_position
+        const Point& dst_position,
+        const DrawProxy& proxy
     ) = 0;
 
     /**
@@ -152,14 +161,14 @@ class Drawable: public ExportableToLua {
      *
      * TODO Since there is get_transition_surface() now, this function can probably be removed.
      */
-    virtual void draw_transition(Transition& transition) = 0;
+    //virtual void draw_transition(Transition& transition) = 0;
 
     /**
      * \brief Returns the surface where transitions on this drawable object
      * are applied.
      * \return The surface for transitions.
      */
-    virtual Surface& get_transition_surface() = 0;
+    //virtual Surface& get_transition_surface() = 0;
 
     virtual void update();
     bool is_suspended() const;

--- a/include/solarus/graphics/GlArbShader.h
+++ b/include/solarus/graphics/GlArbShader.h
@@ -59,8 +59,6 @@ class GlArbShader : public Shader {
 
     void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
 
-    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override {}; //TODO
-
     std::string default_vertex_source() const override;
     std::string default_fragment_source() const override;
   protected:

--- a/include/solarus/graphics/GlArbShader.h
+++ b/include/solarus/graphics/GlArbShader.h
@@ -59,6 +59,8 @@ class GlArbShader : public Shader {
 
     void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
 
+    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override {}; //TODO
+
     std::string default_vertex_source() const override;
     std::string default_fragment_source() const override;
   protected:

--- a/include/solarus/graphics/GlShader.h
+++ b/include/solarus/graphics/GlShader.h
@@ -58,8 +58,6 @@ class GlShader : public Shader {
 
   void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
 
-  virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
-
   std::string default_vertex_source() const override;
   std::string default_fragment_source() const override;
 protected:

--- a/include/solarus/graphics/GlShader.h
+++ b/include/solarus/graphics/GlShader.h
@@ -58,6 +58,8 @@ class GlShader : public Shader {
 
   void render(const VertexArray &array, const Surface &texture, const glm::mat4& mvp_matrix = glm::mat4(), const glm::mat3& uv_matrix = glm::mat3()) override;
 
+  virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
+
   std::string default_vertex_source() const override;
   std::string default_fragment_source() const override;
 protected:

--- a/include/solarus/graphics/RenderTexture.h
+++ b/include/solarus/graphics/RenderTexture.h
@@ -36,7 +36,7 @@ public:
     int get_height() const override;
 
     void draw_other(const SurfaceImpl& texture, const Point& dst_position = Point(0,0));
-    void draw_region_other(const Rectangle &src_rect, const SurfaceImpl &region, const Point& dst_position);
+    void draw_region_other(const Rectangle &src_rect, const SurfaceImpl &texture, const Point& dst_position);
 
     RenderTexture* to_render_texture() override;
 

--- a/include/solarus/graphics/RenderTexture.h
+++ b/include/solarus/graphics/RenderTexture.h
@@ -4,6 +4,7 @@
 #include "solarus/graphics/Color.h"
 #include "solarus/graphics/SDLPtrs.h"
 #include "solarus/graphics/Video.h"
+#include "DrawProxies.h"
 
 namespace Solarus {
 
@@ -35,8 +36,8 @@ public:
     int get_width() const override;
     int get_height() const override;
 
-    void draw_other(const SurfaceImpl& texture, const Point& dst_position = Point(0,0));
-    void draw_region_other(const Rectangle &src_rect, const SurfaceImpl &texture, const Point& dst_position);
+    void draw_other(const SurfaceImpl& texture, const DrawInfos& infos);
+    //void draw_region_other(const Rectangle &src_rect, const SurfaceImpl &texture, const Point& dst_position);
 
     RenderTexture* to_render_texture() override;
 
@@ -47,7 +48,6 @@ public:
     ~RenderTexture(){
     }
 private:
-    SDL_BlendMode make_sdl_blend_mode(const SurfaceImpl &src) const;
     mutable bool surface_dirty = true; /**< is the surface not up to date*/
     mutable SDL_Surface_UniquePtr surface; /**< cpu side pixels data */
     mutable SDL_Texture_UniquePtr target; /**< gpu side pixels data */

--- a/include/solarus/graphics/Shader.h
+++ b/include/solarus/graphics/Shader.h
@@ -28,6 +28,9 @@
 #include "solarus/lua/ExportableToLua.h"
 #include "solarus/lua/LuaContext.h"
 #include "solarus/lua/LuaTools.h"
+
+#include "solarus/graphics/Drawable.h"
+
 #include <string>
 
 #ifdef SOLARUS_HAVE_OPENGL
@@ -41,7 +44,7 @@ namespace Solarus {
 /**
  * \brief Represents a shader for a driver and sampler-independant uses.
  */
-class Shader : public ExportableToLua {
+class Shader : public Drawable::DrawProxy, public ExportableToLua {
   public:
     constexpr static const char* POSITION_NAME = "sol_vertex";
     constexpr static const char* TEXCOORD_NAME = "sol_tex_coord";

--- a/include/solarus/graphics/Shader.h
+++ b/include/solarus/graphics/Shader.h
@@ -87,7 +87,6 @@ class Shader : public DrawProxy, public ExportableToLua {
 
     void render(const Surface &surface, const Rectangle &region, const Size &dst_size, const Point &dst_position = Point(), bool flip_y = false);
     virtual void draw(Surface& dst_surface, const Surface &src_surface, const DrawInfos &infos) const override;
-    virtual bool is_terminal() const override {return true;}
     /**
      * @brief render the given vertex array with this shader, passing the texture and matrices as uniforms
      * @param array a vertex array

--- a/include/solarus/graphics/Shader.h
+++ b/include/solarus/graphics/Shader.h
@@ -44,7 +44,7 @@ namespace Solarus {
 /**
  * \brief Represents a shader for a driver and sampler-independant uses.
  */
-class Shader : public Drawable::DrawProxy, public ExportableToLua {
+class Shader : public DrawProxy, public ExportableToLua {
   public:
     constexpr static const char* POSITION_NAME = "sol_vertex";
     constexpr static const char* TEXCOORD_NAME = "sol_tex_coord";
@@ -86,7 +86,8 @@ class Shader : public Drawable::DrawProxy, public ExportableToLua {
     virtual bool set_uniform_texture(const std::string& uniform_name, const SurfacePtr& value);
 
     void render(const Surface &surface, const Rectangle &region, const Size &dst_size, const Point &dst_position = Point(), bool flip_y = false);
-
+    virtual void draw(Surface& dst_surface, const Surface &src_surface, const DrawInfos &infos) const override;
+    virtual bool is_terminal() const override {return true;}
     /**
      * @brief render the given vertex array with this shader, passing the texture and matrices as uniforms
      * @param array a vertex array

--- a/include/solarus/graphics/Sprite.h
+++ b/include/solarus/graphics/Sprite.h
@@ -114,23 +114,9 @@ class Sprite: public Drawable {
     Rectangle clamp_region(const Rectangle& region) const;
 
     virtual void raw_draw(Surface& dst_surface, const DrawInfos& infos) const override;
+    virtual void raw_draw_region(Surface& dst_surface, const DrawInfos& infos) const override;
 
     virtual Rectangle get_region() const override;
-    /*virtual void raw_draw_region(const Rectangle& region,
-        Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) override;*/
-    /*virtual void shader_draw(
-        const ShaderPtr& shader,
-        Surface& dst_surface,
-        const Point& dst_position
-        ) override;
-    virtual void shader_draw_region(
-        const ShaderPtr& shader,
-        const Rectangle& region,
-        Surface& dst_surface,
-        const Point& dst_position
-        ) override;*/
-    //virtual void draw_transition(Transition& transition) override;
-    //virtual Surface& get_transition_surface() override;
 
     // Lua
     const ScopedLuaRef& get_finished_callback() const;

--- a/include/solarus/graphics/Sprite.h
+++ b/include/solarus/graphics/Sprite.h
@@ -113,9 +113,9 @@ class Sprite: public Drawable {
 
     Rectangle clamp_region(const Rectangle& region) const;
 
-    virtual void raw_draw(Surface& dst_surface, const Point& dst_position) override;
+    virtual void raw_draw(Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) override;
     virtual void raw_draw_region(const Rectangle& region,
-        Surface& dst_surface, const Point& dst_position) override;
+        Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) override;
     virtual void shader_draw(
         const ShaderPtr& shader,
         Surface& dst_surface,
@@ -127,8 +127,8 @@ class Sprite: public Drawable {
         Surface& dst_surface,
         const Point& dst_position
         ) override;
-    virtual void draw_transition(Transition& transition) override;
-    virtual Surface& get_transition_surface() override;
+    //virtual void draw_transition(Transition& transition) override;
+    //virtual Surface& get_transition_surface() override;
 
     // Lua
     const ScopedLuaRef& get_finished_callback() const;

--- a/include/solarus/graphics/Sprite.h
+++ b/include/solarus/graphics/Sprite.h
@@ -113,10 +113,12 @@ class Sprite: public Drawable {
 
     Rectangle clamp_region(const Rectangle& region) const;
 
-    virtual void raw_draw(Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) override;
-    virtual void raw_draw_region(const Rectangle& region,
-        Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) override;
-    virtual void shader_draw(
+    virtual void raw_draw(Surface& dst_surface, const DrawInfos& infos) const override;
+
+    virtual Rectangle get_region() const override;
+    /*virtual void raw_draw_region(const Rectangle& region,
+        Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) override;*/
+    /*virtual void shader_draw(
         const ShaderPtr& shader,
         Surface& dst_surface,
         const Point& dst_position
@@ -126,7 +128,7 @@ class Sprite: public Drawable {
         const Rectangle& region,
         Surface& dst_surface,
         const Point& dst_position
-        ) override;
+        ) override;*/
     //virtual void draw_transition(Transition& transition) override;
     //virtual Surface& get_transition_surface() override;
 

--- a/include/solarus/graphics/SpriteAnimation.h
+++ b/include/solarus/graphics/SpriteAnimation.h
@@ -19,6 +19,7 @@
 
 #include "solarus/core/Common.h"
 #include "solarus/core/Debug.h"
+#include "solarus/graphics/Drawable.h"
 #include "solarus/graphics/SpriteAnimationDirection.h"
 #include "solarus/graphics/SurfacePtr.h"
 #include <string>
@@ -49,7 +50,7 @@ class SpriteAnimation {
 
     int get_next_frame(int current_direction, int current_frame) const;
     void draw(Surface& dst_surface, const Point& dst_position,
-        int current_direction, int current_frame);
+        int current_direction, int current_frame, const Drawable::DrawProxy& proxy) const;
 
     int get_nb_directions() const;
     const SpriteAnimationDirection& get_direction(int direction) const;

--- a/include/solarus/graphics/SpriteAnimation.h
+++ b/include/solarus/graphics/SpriteAnimation.h
@@ -50,7 +50,7 @@ class SpriteAnimation {
 
     int get_next_frame(int current_direction, int current_frame) const;
     void draw(Surface& dst_surface, const Point& dst_position,
-        int current_direction, int current_frame, const Drawable::DrawProxy& proxy) const;
+        int current_direction, int current_frame, const DrawInfos& infos) const;
 
     int get_nb_directions() const;
     const SpriteAnimationDirection& get_direction(int direction) const;

--- a/include/solarus/graphics/SpriteAnimationDirection.h
+++ b/include/solarus/graphics/SpriteAnimationDirection.h
@@ -52,7 +52,7 @@ class SpriteAnimationDirection {
     int get_nb_frames() const;
     const Rectangle& get_frame(int frame) const;
     void draw(Surface& dst_surface, const Point& dst_position,
-        int current_frame, Surface& src_image, const Drawable::DrawProxy &proxy) const;
+        int current_frame, Surface& src_image, const DrawInfos &infos) const;
 
     // pixel collisions
     void enable_pixel_collisions(Surface& src_image);

--- a/include/solarus/graphics/SpriteAnimationDirection.h
+++ b/include/solarus/graphics/SpriteAnimationDirection.h
@@ -21,6 +21,7 @@
 #include "solarus/core/Debug.h"
 #include "solarus/core/PixelBits.h"
 #include "solarus/core/Rectangle.h"
+#include "solarus/graphics/Drawable.h"
 #include <vector>
 
 namespace Solarus {
@@ -51,7 +52,7 @@ class SpriteAnimationDirection {
     int get_nb_frames() const;
     const Rectangle& get_frame(int frame) const;
     void draw(Surface& dst_surface, const Point& dst_position,
-        int current_frame, Surface& src_image);
+        int current_frame, Surface& src_image, const Drawable::DrawProxy &proxy) const;
 
     // pixel collisions
     void enable_pixel_collisions(Surface& src_image);

--- a/include/solarus/graphics/Surface.h
+++ b/include/solarus/graphics/Surface.h
@@ -51,9 +51,11 @@ class Surface: public Drawable {
   public:
     using SurfaceImpl_UniquePtr = std::unique_ptr<SurfaceImpl>;
 
+    /**
+     * @brief terminal DrawProxy for simple surface draw
+     */
     struct SurfaceDraw : public DrawProxy {
       virtual void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override;
-      virtual bool is_terminal() const override {return true;}
     };
     /**
      * \brief The base directory to use when opening image files.
@@ -101,6 +103,11 @@ class Surface: public Drawable {
 
     // Implementation from Drawable.
     virtual void raw_draw(
+        Surface& dst_surface,
+        const DrawInfos& infos
+    ) const override;
+
+    virtual void raw_draw_region(
         Surface& dst_surface,
         const DrawInfos& infos
     ) const override;

--- a/include/solarus/graphics/Surface.h
+++ b/include/solarus/graphics/Surface.h
@@ -52,7 +52,7 @@ class Surface: public Drawable {
     using SurfaceImpl_UniquePtr = std::unique_ptr<SurfaceImpl>;
 
     struct SurfaceDraw : public DrawProxy {
-      virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
+      virtual void draw(Surface& dst_surface, Surface& src_surface, const DrawInfos& params) const override;
     };
     /**
      * \brief The base directory to use when opening image files.

--- a/include/solarus/graphics/Surface.h
+++ b/include/solarus/graphics/Surface.h
@@ -52,7 +52,8 @@ class Surface: public Drawable {
     using SurfaceImpl_UniquePtr = std::unique_ptr<SurfaceImpl>;
 
     struct SurfaceDraw : public DrawProxy {
-      virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
+      virtual void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& params) const override;
+      virtual bool is_terminal() const override {return true;}
     };
     /**
      * \brief The base directory to use when opening image files.
@@ -86,8 +87,6 @@ class Surface: public Drawable {
     void clear(const Rectangle& where);
     void fill_with_color(const Color& color);
     void fill_with_color(const Color& color, const Rectangle& where);
-    uint8_t get_opacity() const;
-    void set_opacity(uint8_t opacity);
 
     SurfaceImpl &get_internal_surface();
     const SurfaceImpl &get_internal_surface() const;
@@ -103,37 +102,20 @@ class Surface: public Drawable {
     // Implementation from Drawable.
     virtual void raw_draw(
         Surface& dst_surface,
-        const Point& dst_position,
-        const DrawProxy& proxy = Surface::draw_proxy
-    ) override;
-    virtual void raw_draw_region(
-        const Rectangle& region,
-        Surface& dst_surface,
-        const Point& dst_position,
-        const DrawProxy& proxy = Surface::draw_proxy
-    ) override;
-    virtual void shader_draw(
-        const ShaderPtr& shader,
-        Surface& dst_surface,
-        const Point& dst_position
-        ) override;
-    virtual void shader_draw_region(
-        const ShaderPtr& shader,
-        const Rectangle& region,
-        Surface& dst_surface,
-        const Point& dst_position
-        ) override;
-    //virtual void draw_transition(Transition& transition) override;
+        const DrawInfos& infos
+    ) const override;
+
+    virtual Rectangle get_region() const override;
+
     void apply_pixel_filter(
         const SoftwarePixelFilter& pixel_filter, Surface& dst_surface) const;
-    //virtual Surface& get_transition_surface() override;
-    SDL_BlendMode get_sdl_blend_mode() const;
+
+    static SDL_BlendMode make_sdl_blend_mode(const SurfaceImpl &dst_surface, const SurfaceImpl &src_surface, BlendMode blend_mode);
 
     const std::string& get_lua_type_name() const override;
 
     static SurfaceDraw draw_proxy;
   private:
-    uint8_t opacity;
     uint32_t get_pixel(int index) const;
     uint32_t get_color_value(const Color& color) const;
 

--- a/include/solarus/graphics/Surface.h
+++ b/include/solarus/graphics/Surface.h
@@ -51,6 +51,9 @@ class Surface: public Drawable {
   public:
     using SurfaceImpl_UniquePtr = std::unique_ptr<SurfaceImpl>;
 
+    struct SurfaceDraw : public DrawProxy {
+      virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
+    };
     /**
      * \brief The base directory to use when opening image files.
      */
@@ -100,12 +103,14 @@ class Surface: public Drawable {
     // Implementation from Drawable.
     virtual void raw_draw(
         Surface& dst_surface,
-        const Point& dst_position
+        const Point& dst_position,
+        const DrawProxy& proxy = Surface::draw_proxy
     ) override;
     virtual void raw_draw_region(
         const Rectangle& region,
         Surface& dst_surface,
-        const Point& dst_position
+        const Point& dst_position,
+        const DrawProxy& proxy = Surface::draw_proxy
     ) override;
     virtual void shader_draw(
         const ShaderPtr& shader,
@@ -118,13 +123,15 @@ class Surface: public Drawable {
         Surface& dst_surface,
         const Point& dst_position
         ) override;
-    virtual void draw_transition(Transition& transition) override;
+    //virtual void draw_transition(Transition& transition) override;
     void apply_pixel_filter(
         const SoftwarePixelFilter& pixel_filter, Surface& dst_surface) const;
-    virtual Surface& get_transition_surface() override;
+    //virtual Surface& get_transition_surface() override;
     SDL_BlendMode get_sdl_blend_mode() const;
 
     const std::string& get_lua_type_name() const override;
+
+    static SurfaceDraw draw_proxy;
   private:
     uint8_t opacity;
     uint32_t get_pixel(int index) const;
@@ -134,6 +141,7 @@ class Surface: public Drawable {
     static SurfaceImpl* get_surface_from_file(
         const std::string& file_name,
         ImageDirectory base_directory);
+
 
     SurfaceImpl_UniquePtr
         internal_surface;                 /**< The SDL_Surface encapsulated. */

--- a/include/solarus/graphics/SurfaceImpl.h
+++ b/include/solarus/graphics/SurfaceImpl.h
@@ -16,7 +16,6 @@ class Surface;
  */
 class SurfaceImpl
 {
-    friend class Surface;
 public:
     /**
      * @brief get the underlying SDL_Texture
@@ -48,12 +47,6 @@ public:
     virtual int get_height() const = 0;
 
     /**
-     * @brief access SurfaceImpl parent
-     * @return parent reference
-     */
-    const Surface& parent() const;
-
-    /**
      * @brief upload potentially modified surface
      *
      * When modifying pixels of the Surface, we have
@@ -75,7 +68,6 @@ public:
     bool is_premultiplied() const;
     void set_premultiplied(bool a_premultiplied);
 private:
-    Surface* _parent; /**< pointer to owning surface */
     bool premultiplied = false;
 };
 

--- a/include/solarus/graphics/TextSurface.h
+++ b/include/solarus/graphics/TextSurface.h
@@ -105,8 +105,10 @@ class TextSurface: public Drawable {
     int get_height() const;
     virtual Size get_size() const override;
 
-    virtual void raw_draw(Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) override;
-    virtual void raw_draw_region(const Rectangle& region,
+    virtual void raw_draw(Surface& dst_surface,const DrawInfos& infos) const override;
+
+    virtual Rectangle get_region() const override;
+    /*virtual void raw_draw_region(const Rectangle& region,
         Surface& dst_surface, const Point& dst_position, const DrawProxy &proxy) override;
     virtual void shader_draw(
         const ShaderPtr& shader,
@@ -118,7 +120,7 @@ class TextSurface: public Drawable {
         const Rectangle& region,
         Surface& dst_surface,
         const Point& dst_position
-        ) override;
+        ) override;*/
     //virtual void draw_transition(Transition& transition) override;
     //virtual Surface& get_transition_surface() override;
 

--- a/include/solarus/graphics/TextSurface.h
+++ b/include/solarus/graphics/TextSurface.h
@@ -105,9 +105,9 @@ class TextSurface: public Drawable {
     int get_height() const;
     virtual Size get_size() const override;
 
-    virtual void raw_draw(Surface& dst_surface, const Point& dst_position) override;
+    virtual void raw_draw(Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) override;
     virtual void raw_draw_region(const Rectangle& region,
-        Surface& dst_surface, const Point& dst_position) override;
+        Surface& dst_surface, const Point& dst_position, const DrawProxy &proxy) override;
     virtual void shader_draw(
         const ShaderPtr& shader,
         Surface& dst_surface,
@@ -119,8 +119,8 @@ class TextSurface: public Drawable {
         Surface& dst_surface,
         const Point& dst_position
         ) override;
-    virtual void draw_transition(Transition& transition) override;
-    virtual Surface& get_transition_surface() override;
+    //virtual void draw_transition(Transition& transition) override;
+    //virtual Surface& get_transition_surface() override;
 
     virtual const std::string& get_lua_type_name() const override;
 

--- a/include/solarus/graphics/TextSurface.h
+++ b/include/solarus/graphics/TextSurface.h
@@ -106,23 +106,9 @@ class TextSurface: public Drawable {
     virtual Size get_size() const override;
 
     virtual void raw_draw(Surface& dst_surface,const DrawInfos& infos) const override;
+    virtual void raw_draw_region(Surface& dst_surface,const DrawInfos& infos) const override;
 
     virtual Rectangle get_region() const override;
-    /*virtual void raw_draw_region(const Rectangle& region,
-        Surface& dst_surface, const Point& dst_position, const DrawProxy &proxy) override;
-    virtual void shader_draw(
-        const ShaderPtr& shader,
-        Surface& dst_surface,
-        const Point& dst_position
-        ) override;
-    virtual void shader_draw_region(
-        const ShaderPtr& shader,
-        const Rectangle& region,
-        Surface& dst_surface,
-        const Point& dst_position
-        ) override;*/
-    //virtual void draw_transition(Transition& transition) override;
-    //virtual Surface& get_transition_surface() override;
 
     virtual const std::string& get_lua_type_name() const override;
 

--- a/include/solarus/graphics/Transition.h
+++ b/include/solarus/graphics/Transition.h
@@ -19,6 +19,10 @@
 
 #include "solarus/core/Common.h"
 #include "solarus/core/EnumInfo.h"
+#include "solarus/core/Rectangle.h"
+#include "solarus/graphics/ShaderPtr.h"
+#include "solarus/graphics/Drawable.h"
+
 #include <map>
 #include <string>
 
@@ -32,7 +36,7 @@ class Surface;
  *
  * The transitions may be applied to maps or any surface.
  */
-class SOLARUS_API Transition {
+class SOLARUS_API Transition : public Drawable::DrawProxy {
 
   public:
 
@@ -94,7 +98,7 @@ class SOLARUS_API Transition {
      * \brief Draws the transition effect on a surface.
      * \param dst_surface the surface to draw
      */
-    virtual void draw(Surface& dst_surface) = 0;
+    //virtual void draw(Surface& dst_surface, const Surface& src_surface, const Rectangle& region, const Point& destination) = 0;
 
   protected:
 

--- a/include/solarus/graphics/Transition.h
+++ b/include/solarus/graphics/Transition.h
@@ -36,7 +36,7 @@ class Surface;
  *
  * The transitions may be applied to maps or any surface.
  */
-class SOLARUS_API Transition : public Drawable::DrawProxy {
+class SOLARUS_API Transition : public DrawProxy {
 
   public:
 
@@ -58,10 +58,8 @@ class SOLARUS_API Transition : public Drawable::DrawProxy {
     };
 
     virtual ~Transition();
-    static Transition* create(
-        Style style,
+    static Transition* create(Style style,
         Direction direction,
-        Surface& dst_surface,
         Game* game = nullptr);
 
     Game* get_game() const;
@@ -93,6 +91,11 @@ class SOLARUS_API Transition : public Drawable::DrawProxy {
      * \brief Updates this transition effect.
      */
     virtual void update() = 0;
+
+    /**
+     * @brief edit target Drawable to reflect transition side effects
+     */
+    virtual void finish(Drawable& target) const {(void)target;}
 
     /**
      * \brief Draws the transition effect on a surface.

--- a/include/solarus/graphics/Transition.h
+++ b/include/solarus/graphics/Transition.h
@@ -36,7 +36,7 @@ class Surface;
  *
  * The transitions may be applied to maps or any surface.
  */
-class SOLARUS_API Transition : public Drawable::DrawProxy {
+class SOLARUS_API Transition : public DrawProxy {
 
   public:
 

--- a/include/solarus/graphics/TransitionFade.h
+++ b/include/solarus/graphics/TransitionFade.h
@@ -32,7 +32,7 @@ class TransitionFade: public Transition {
 
   public:
 
-    TransitionFade(Direction direction, Surface& dst_surface);
+    TransitionFade(Direction direction);
 
     void set_delay(uint32_t delay);
 
@@ -45,7 +45,7 @@ class TransitionFade: public Transition {
     virtual bool is_finished() const override;
     virtual void notify_suspended(bool suspended) override;
     virtual void update() override;
-    virtual void draw(Surface& surface) override;
+    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
 
   private:
 
@@ -58,7 +58,6 @@ class TransitionFade: public Transition {
     uint32_t next_frame_date;
     uint32_t delay;
 
-    Surface* dst_surface;
     bool colored;
     Color transition_color;
 

--- a/include/solarus/graphics/TransitionFade.h
+++ b/include/solarus/graphics/TransitionFade.h
@@ -45,7 +45,7 @@ class TransitionFade: public Transition {
     virtual bool is_finished() const override;
     virtual void notify_suspended(bool suspended) override;
     virtual void update() override;
-    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
+    virtual void draw(Surface& dst_surface, Surface& src_surface,const DrawInfos& params) const override;
 
   private:
 

--- a/include/solarus/graphics/TransitionFade.h
+++ b/include/solarus/graphics/TransitionFade.h
@@ -45,7 +45,8 @@ class TransitionFade: public Transition {
     virtual bool is_finished() const override;
     virtual void notify_suspended(bool suspended) override;
     virtual void update() override;
-    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
+    virtual void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& infos) const override;
+    virtual void finish(Drawable& target) const override;
 
   private:
 

--- a/include/solarus/graphics/TransitionImmediate.h
+++ b/include/solarus/graphics/TransitionImmediate.h
@@ -39,7 +39,7 @@ class TransitionImmediate: public Transition {
     virtual bool is_finished() const override;
     virtual void notify_suspended(bool suspended) override;
     virtual void update() override;
-    virtual void draw(Surface& dst_surface) override;
+    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
 
 };
 

--- a/include/solarus/graphics/TransitionImmediate.h
+++ b/include/solarus/graphics/TransitionImmediate.h
@@ -39,7 +39,7 @@ class TransitionImmediate: public Transition {
     virtual bool is_finished() const override;
     virtual void notify_suspended(bool suspended) override;
     virtual void update() override;
-    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
+    virtual void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& infos) const override;
 
 };
 

--- a/include/solarus/graphics/TransitionScrolling.h
+++ b/include/solarus/graphics/TransitionScrolling.h
@@ -47,14 +47,13 @@ class TransitionScrolling: public Transition {
     virtual bool is_finished() const override;
     virtual void notify_suspended(bool suspended) override;
     virtual void update() override;
-    virtual void draw(Surface& dst_surface) override;
+    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
 
   private:
 
     void scroll();
     Rectangle get_previous_map_dst_position(int scrolling_direction);
 
-    SurfacePtr both_maps_surface;         /**< an intermediate surface where the two map surfaces will be blitted */
     int scrolling_direction;              /**< direction of the scrolling (0 to 3) */
     uint32_t next_scroll_date;            /**< date of the next scrolling step */
 

--- a/include/solarus/graphics/TransitionScrolling.h
+++ b/include/solarus/graphics/TransitionScrolling.h
@@ -47,7 +47,7 @@ class TransitionScrolling: public Transition {
     virtual bool is_finished() const override;
     virtual void notify_suspended(bool suspended) override;
     virtual void update() override;
-    virtual void draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const override;
+    virtual void draw(Surface& dst_surface, const Surface& src_surface, const DrawInfos& infos) const override;
 
   private:
 

--- a/src/core/Game.cpp
+++ b/src/core/Game.cpp
@@ -578,9 +578,10 @@ void Game::draw(const SurfacePtr& dst_surface) {
     if (camera != nullptr) {
       const SurfacePtr& camera_surface = camera->get_surface();
       if (transition != nullptr) {
-        transition->draw(*camera_surface);
+        transition->draw(*dst_surface,*camera_surface,Rectangle(camera_surface->get_size()),Point());
+      } else { //TODO handle this case
+        camera_surface->draw(dst_surface, camera->get_position_on_screen());
       }
-      camera_surface->draw(dst_surface, camera->get_position_on_screen());
     }
 
     // Draw the built-in dialog box if any.

--- a/src/core/Game.cpp
+++ b/src/core/Game.cpp
@@ -395,7 +395,6 @@ void Game::update_transitions() {
       transition = std::unique_ptr<Transition>(Transition::create(
           transition_style,
           Transition::Direction::CLOSING,
-          *current_map->get_camera_surface(),
           this
       ));
       transition->start();
@@ -478,7 +477,6 @@ void Game::update_transitions() {
         transition = std::unique_ptr<Transition>(Transition::create(
             transition_style,
             Transition::Direction::OPENING,
-            *current_map->get_camera_surface(),
             this
         ));
         transition->start();
@@ -518,7 +516,6 @@ void Game::update_transitions() {
     transition = std::unique_ptr<Transition>(Transition::create(
         transition_style,
         Transition::Direction::OPENING,
-        *current_map->get_camera_surface(),
         this
     ));
 
@@ -578,7 +575,7 @@ void Game::draw(const SurfacePtr& dst_surface) {
     if (camera != nullptr) {
       const SurfacePtr& camera_surface = camera->get_surface();
       if (transition != nullptr) {
-        transition->draw(*dst_surface,*camera_surface,Rectangle(camera_surface->get_size()),Point());
+        transition->draw(*dst_surface,*camera_surface,DrawInfos(Rectangle(camera_surface->get_size()),Point(),BlendMode::BLEND,255,Surface::draw_proxy));
       } else { //TODO handle this case
         camera_surface->draw(dst_surface, camera->get_position_on_screen());
       }
@@ -888,7 +885,6 @@ void Game::restart() {
     transition = std::unique_ptr<Transition>(Transition::create(
         Transition::Style::FADE,
         Transition::Direction::CLOSING,
-        *current_map->get_camera_surface(),
         this
     ));
     transition->start();

--- a/src/graphics/Drawable.cpp
+++ b/src/graphics/Drawable.cpp
@@ -19,6 +19,7 @@
 #include "solarus/graphics/Transition.h"
 #include "solarus/lua/LuaContext.h"
 #include "solarus/movements/Movement.h"
+#include "solarus/graphics/Surface.h"
 #include <lua.hpp>
 #include <utility>
 
@@ -233,13 +234,13 @@ void Drawable::draw(const SurfacePtr& dst_surface, int x, int y) {
 void Drawable::draw(const SurfacePtr& dst_surface,
     const Point& dst_position) {
 
-  if (transition != nullptr) {
-    draw_transition(*transition);
-  }
-  if(shader) {
-    shader_draw(shader,*dst_surface,dst_position);
+  if (transition) {
+    raw_draw(*dst_surface,dst_position + xy,*transition);
+  } else if(shader) { //TODO fix transition and shader combination
+    const Shader& s = *shader;
+    raw_draw(*dst_surface, dst_position + xy, (const DrawProxy&)s);
   } else {
-    raw_draw(*dst_surface, dst_position + xy);
+    raw_draw(*dst_surface, dst_position + xy,Surface::draw_proxy);
   }
 }
 
@@ -266,13 +267,12 @@ void Drawable::draw_region(
     const SurfacePtr& dst_surface,
     const Point& dst_position) {
 
-  if (transition != nullptr) {
-    draw_transition(*transition);
-  }
-  if(shader) {
-    shader_draw_region(shader,region,*dst_surface,dst_position);
+  if (transition) {
+    raw_draw_region(region, *dst_surface, dst_position + xy, *transition);
+  } else if(shader) { //TODO fix transition and shader combination
+    raw_draw_region(region, *dst_surface, dst_position + xy,(const DrawProxy&)*shader.get());
   } else {
-    raw_draw_region(region, *dst_surface, dst_position + xy);
+    raw_draw_region(region, *dst_surface, dst_position + xy,Surface::draw_proxy);
   }
 }
 

--- a/src/graphics/Drawable.cpp
+++ b/src/graphics/Drawable.cpp
@@ -211,7 +211,7 @@ void Drawable::set_suspended(bool suspended) {
  * \brief Draws this object, applying dynamic effects.
  * \param dst_surface the destination surface
  */
-void Drawable::draw(const SurfacePtr& dst_surface) {
+void Drawable::draw(const SurfacePtr& dst_surface) const {
 
   draw(dst_surface, Point(0, 0));
 }
@@ -222,7 +222,7 @@ void Drawable::draw(const SurfacePtr& dst_surface) {
  * \param x x coordinate of where to draw
  * \param y y coordinate of where to draw
  */
-void Drawable::draw(const SurfacePtr& dst_surface, int x, int y) {
+void Drawable::draw(const SurfacePtr& dst_surface, int x, int y) const {
   draw(dst_surface, Point(x, y));
 }
 
@@ -233,8 +233,24 @@ void Drawable::draw(const SurfacePtr& dst_surface, int x, int y) {
  * (will be added to the position obtained by previous movements)
  */
 void Drawable::draw(const SurfacePtr& dst_surface,
-    const Point& dst_position) {
-  draw_region(get_region(),dst_surface,dst_position);
+    const Point& dst_position) const {
+  //draw_region(get_region(),dst_surface,dst_position);
+  if (transition) {
+    draw(dst_surface,dst_position,DrawProxyChain<2>({*transition,terminal()}));
+  } else {
+    draw(dst_surface, dst_position,terminal());
+  }
+}
+
+/**
+ * @brief Draws this object, applying given dynamic effects
+ * @param dst_surface the destination surface
+ * @param dst_position position on this surface
+ * @param proxy
+ */
+void Drawable::draw(const SurfacePtr &dst_surface, const Point &dst_position, const DrawProxy& proxy) const {
+  Point off_dst = dst_position + xy;
+  raw_draw(*dst_surface, DrawInfos(get_region(),off_dst,get_blend_mode(),get_opacity(),proxy));
 }
 
 /**
@@ -244,7 +260,7 @@ void Drawable::draw(const SurfacePtr& dst_surface,
  */
 void Drawable::draw_region(
     const Rectangle& region,
-    const SurfacePtr& dst_surface) {
+    const SurfacePtr& dst_surface) const {
   draw_region(region, dst_surface, Point(0, 0));
 }
 
@@ -257,7 +273,7 @@ void Drawable::draw_region(
  */
 void Drawable::draw_region(const Rectangle& region,
     const SurfacePtr& dst_surface,
-    const Point& dst_position) {
+    const Point& dst_position) const {
   if (transition) {
     draw_region(region,dst_surface,dst_position,DrawProxyChain<2>({*transition,terminal()}));
   } else {
@@ -274,9 +290,9 @@ void Drawable::draw_region(const Rectangle& region,
  */
 void Drawable::draw_region(const Rectangle& region,
     const SurfacePtr& dst_surface,
-    const Point& dst_position, const DrawProxy &proxy) {
+    const Point& dst_position, const DrawProxy &proxy) const {
   Point off_dst = dst_position + xy;
-  raw_draw(*dst_surface, DrawInfos(region,off_dst,get_blend_mode(),get_opacity(),proxy));
+  raw_draw_region(*dst_surface, DrawInfos(region,off_dst,get_blend_mode(),get_opacity(),proxy));
 }
 
 /**

--- a/src/graphics/GlShader.cpp
+++ b/src/graphics/GlShader.cpp
@@ -24,6 +24,7 @@
 #include "solarus/graphics/Surface.h"
 #include "solarus/graphics/Video.h"
 #include "solarus/graphics/ShaderContext.h"
+#include "solarus/graphics/RenderTexture.h"
 
 #include "solarus/third_party/glm/gtc/type_ptr.hpp"
 #include "solarus/third_party/glm/gtx/transform.hpp"
@@ -350,6 +351,22 @@ void GlShader::render(const VertexArray& array, const Surface& texture, const gl
 
   ctx.glBindBuffer(GL_ARRAY_BUFFER,previous_buffer);
   ctx.glUseProgram(previous_program);
+}
+
+void GlShader::draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& dst_position) const {
+    dst_surface.request_render().with_target([&](SDL_Renderer* r){
+      SDL_BlendMode target = src_surface.get_sdl_blend_mode();
+      SDL_BlendMode current;
+      SDL_GetRenderDrawBlendMode(r,&current);
+      if(target != current) { //Blend mode need change
+        SDL_SetRenderDrawBlendMode(r,target);
+        SDL_RenderDrawPoint(r,-100,-100); //Draw a point offscreen to force blendmode change
+      }
+      //TODO fix this ugliness
+      GlShader* that = const_cast<GlShader*>(this);
+      that->set_uniform_1f("sol_opacity",src_surface.get_opacity()/256.f);
+      that->Shader::render(src_surface,region,dst_surface.get_size(),dst_position);
+    });
 }
 
 /**

--- a/src/graphics/GlShader.cpp
+++ b/src/graphics/GlShader.cpp
@@ -353,21 +353,7 @@ void GlShader::render(const VertexArray& array, const Surface& texture, const gl
   ctx.glUseProgram(previous_program);
 }
 
-void GlShader::draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& dst_position) const {
-    dst_surface.request_render().with_target([&](SDL_Renderer* r){
-      SDL_BlendMode target = src_surface.get_sdl_blend_mode();
-      SDL_BlendMode current;
-      SDL_GetRenderDrawBlendMode(r,&current);
-      if(target != current) { //Blend mode need change
-        SDL_SetRenderDrawBlendMode(r,target);
-        SDL_RenderDrawPoint(r,-100,-100); //Draw a point offscreen to force blendmode change
-      }
-      //TODO fix this ugliness
-      GlShader* that = const_cast<GlShader*>(this);
-      that->set_uniform_1f("sol_opacity",src_surface.get_opacity()/256.f);
-      that->Shader::render(src_surface,region,dst_surface.get_size(),dst_position);
-    });
-}
+
 
 /**
  * \brief Returns the location of a uniform value in the shader program.

--- a/src/graphics/RenderTexture.cpp
+++ b/src/graphics/RenderTexture.cpp
@@ -59,10 +59,9 @@ SDL_Texture* RenderTexture::get_texture() const {
 }
 
 /**
- * @brief draw region of another surfaceimpl on this one //TODO update doc
- * @param src_rect source region to draw
- * @param texture source surface
- * @param dst_position position where to draw
+ * @brief draw other surface impl on this one using given infos
+ * @param texture the surface to draw here
+ * @param infos draw info bundle
  */
 void RenderTexture::draw_other(const SurfaceImpl& texture, const DrawInfos& infos) {
   with_target([&](SDL_Renderer* renderer){

--- a/src/graphics/Sprite.cpp
+++ b/src/graphics/Sprite.cpp
@@ -775,11 +775,9 @@ void Sprite::update() {
  * \brief Draws the sprite on a surface, with its current animation,
  * direction and frame.
  * \param dst_surface The destination surface.
- * \param dst_position Coordinates on the destination surface
- * (the origin will be placed at this position).
+ * \param infos draw infos, region is ignored in this case
  */
-/*void Sprite::raw_draw(Surface& dst_surface,
-    const Point& dst_position, const DrawProxy &proxy) {
+void Sprite::raw_draw(Surface& dst_surface,const DrawInfos& infos) const {
 
   if (current_animation == nullptr) {
     return;
@@ -787,21 +785,15 @@ void Sprite::update() {
 
   if (!is_animation_finished()
       && (blink_delay == 0 || blink_is_sprite_visible)) {
-    /*draw_intermediate();
-    get_intermediate_surface().set_blend_mode(get_blend_mode());
-    get_intermediate_surface().draw_region(
-        Rectangle(get_size()),
-        std::static_pointer_cast<Surface>(dst_surface.shared_from_this()),
-        dst_position - get_origin()
-    );*/
-    /*current_animation->draw(
+
+    current_animation->draw(
           dst_surface,
-          dst_position /*- get_origin()*//*,
+          infos.dst_position,
           current_direction,
           current_frame,
-          proxy);
+          infos);
   }
-}*/
+}
 
 /**
  * @brief compute region of the spritesheet to draw given crop region
@@ -838,8 +830,7 @@ Rectangle Sprite::clamp_region(const Rectangle& region) const {
  * \param dst_position Coordinates on the destination surface.
  * The origin point of the sprite will appear at these coordinates.
  */
-void Sprite::raw_draw(Surface& dst_surface, const DrawInfos& infos) const {
-
+void Sprite::raw_draw_region(Surface& dst_surface, const DrawInfos& infos) const {
   if (current_animation == nullptr) {
     return;
   }
@@ -876,8 +867,6 @@ void Sprite::raw_draw(Surface& dst_surface, const DrawInfos& infos) const {
       src_position,
       get_origin()
     };
-
-
 
     current_animation->draw(
           dst_surface,

--- a/src/graphics/Sprite.cpp
+++ b/src/graphics/Sprite.cpp
@@ -102,7 +102,6 @@ Sprite::Sprite(const std::string& id):
   paused(false),
   finished(false),
   synchronize_to(nullptr),
-  intermediate_surface(nullptr),
   blink_delay(0),
   blink_is_sprite_visible(true),
   blink_next_change_date(0),
@@ -763,14 +762,14 @@ void Sprite::update() {
  * @param dst_surface
  * @param dst_position
  */
-void Sprite::draw_intermediate() const {
+/*void Sprite::draw_intermediate() const {
     get_intermediate_surface().clear();
     current_animation->draw(
         get_intermediate_surface(),
         get_origin(),
         current_direction,
         current_frame);
-}
+}*/
 
 /**
  * \brief Draws the sprite on a surface, with its current animation,
@@ -789,13 +788,18 @@ void Sprite::raw_draw(
 
   if (!is_animation_finished()
       && (blink_delay == 0 || blink_is_sprite_visible)) {
-    draw_intermediate();
+    /*draw_intermediate();
     get_intermediate_surface().set_blend_mode(get_blend_mode());
     get_intermediate_surface().draw_region(
         Rectangle(get_size()),
         std::static_pointer_cast<Surface>(dst_surface.shared_from_this()),
         dst_position - get_origin()
-    );
+    );*/
+    current_animation->draw(
+          dst_surface,
+          dst_position /*- get_origin()*/,
+          current_direction,
+          current_frame);
   }
 }
 
@@ -846,7 +850,7 @@ void Sprite::raw_draw_region(
   if (!is_animation_finished()
       && (blink_delay == 0 || blink_is_sprite_visible)) {
 
-    draw_intermediate();
+    //draw_intermediate();
 
     // If the region is bigger than the current frame, clip it.
     // Otherwise, more than the current frame could be visible.
@@ -856,12 +860,17 @@ void Sprite::raw_draw_region(
     Point dst_position2 = dst_position;
     dst_position2 += src_position.get_xy(); // Let a space for the part outside the region.
     dst_position2 -= get_origin();                // Input coordinates were relative to the origin.
-    get_intermediate_surface().set_blend_mode(get_blend_mode());
+    /*get_intermediate_surface().set_blend_mode(get_blend_mode());
     get_intermediate_surface().draw_region(
         src_position,
         std::static_pointer_cast<Surface>(dst_surface.shared_from_this()),
         dst_position2
-    );
+    );*/
+    current_animation->draw(
+          dst_surface,
+          dst_position,
+          current_direction,
+          current_frame);
   }
 }
 
@@ -884,14 +893,15 @@ void Sprite::shader_draw(
 
   if (!is_animation_finished()
       && (blink_delay == 0 || blink_is_sprite_visible)) {
-    draw_intermediate();
+    //TODO redo this
+    /*draw_intermediate();
     dst_surface.request_render().with_target([&](SDL_Renderer*){
       get_intermediate_surface().set_blend_mode(get_blend_mode());
       get_intermediate_surface().shader_draw_region(shader,
                                                     Rectangle(get_size()),
                                                     dst_surface,
                                                     dst_position-get_origin());
-    });
+    });*/
   }
 }
 
@@ -917,7 +927,8 @@ void Sprite::shader_draw_region(
   if (!is_animation_finished()
       && (blink_delay == 0 || blink_is_sprite_visible)) {
 
-    draw_intermediate();
+    //TODO redo this...
+    /*draw_intermediate();
 
     // If the region is bigger than the current frame, clip it.
     // Otherwise, more than the current frame could be visible.
@@ -931,7 +942,7 @@ void Sprite::shader_draw_region(
     dst_surface.request_render().with_target([&](SDL_Renderer*){
       get_intermediate_surface().set_blend_mode(get_blend_mode());
       get_intermediate_surface().shader_draw_region(shader,src_position,dst_surface,dst_position2);
-    });
+    });*/
   }
 }
 
@@ -940,8 +951,8 @@ void Sprite::shader_draw_region(
  * \param transition The transition effect to apply.
  */
 void Sprite::draw_transition(Transition& transition) {
-
-  transition.draw(get_intermediate_surface());
+  //TODO reinvent that
+  //transition.draw(get_intermediate_surface());
 }
 
 /**
@@ -950,6 +961,7 @@ void Sprite::draw_transition(Transition& transition) {
  * \return The surface for transitions.
  */
 Surface& Sprite::get_transition_surface() {
+  //TODO meh
   return get_intermediate_surface();
 }
 

--- a/src/graphics/SpriteAnimation.cpp
+++ b/src/graphics/SpriteAnimation.cpp
@@ -142,7 +142,7 @@ int SpriteAnimation::get_next_frame(
  * \param current_frame the frame to show in this direction
  */
 void SpriteAnimation::draw(Surface& dst_surface,
-    const Point& dst_position, int current_direction, int current_frame, const Drawable::DrawProxy &proxy) const {
+    const Point& dst_position, int current_direction, int current_frame, const DrawInfos &infos) const {
 
   if (src_image == nullptr) {
     return;
@@ -157,7 +157,7 @@ void SpriteAnimation::draw(Surface& dst_surface,
     Debug::die(oss.str());
   }
   directions[current_direction].draw(dst_surface, dst_position,
-      current_frame, *src_image, proxy);
+      current_frame, *src_image, infos);
 }
 
 /**

--- a/src/graphics/SpriteAnimation.cpp
+++ b/src/graphics/SpriteAnimation.cpp
@@ -142,7 +142,7 @@ int SpriteAnimation::get_next_frame(
  * \param current_frame the frame to show in this direction
  */
 void SpriteAnimation::draw(Surface& dst_surface,
-    const Point& dst_position, int current_direction, int current_frame) {
+    const Point& dst_position, int current_direction, int current_frame, const Drawable::DrawProxy &proxy) const {
 
   if (src_image == nullptr) {
     return;
@@ -157,7 +157,7 @@ void SpriteAnimation::draw(Surface& dst_surface,
     Debug::die(oss.str());
   }
   directions[current_direction].draw(dst_surface, dst_position,
-      current_frame, *src_image);
+      current_frame, *src_image, proxy);
 }
 
 /**

--- a/src/graphics/SpriteAnimation.cpp
+++ b/src/graphics/SpriteAnimation.cpp
@@ -140,6 +140,7 @@ int SpriteAnimation::get_next_frame(
  * (the origin point will be drawn at this position)
  * \param current_direction the direction to show
  * \param current_frame the frame to show in this direction
+ * \param infos draw infos bundle
  */
 void SpriteAnimation::draw(Surface& dst_surface,
     const Point& dst_position, int current_direction, int current_frame, const DrawInfos &infos) const {

--- a/src/graphics/SpriteAnimationDirection.cpp
+++ b/src/graphics/SpriteAnimationDirection.cpp
@@ -80,7 +80,7 @@ const Rectangle& SpriteAnimationDirection::get_frame(int frame) const {
  * \param src_image the image from which the frame is extracted
  */
 void SpriteAnimationDirection::draw(Surface& dst_surface,
-                                    const Point& dst_position, int current_frame, Surface& src_image, const Drawable::DrawProxy& proxy) const {
+                                    const Point& dst_position, int current_frame, Surface& src_image, const DrawInfos &infos) const {
 
   const Rectangle& current_frame_rect = get_frame(current_frame);
 
@@ -88,12 +88,7 @@ void SpriteAnimationDirection::draw(Surface& dst_surface,
   Point position_top_left = dst_position;
   position_top_left -= origin;
 
-  src_image.raw_draw_region(
-        current_frame_rect,
-        dst_surface,
-        position_top_left,
-        proxy
-        );
+  infos.proxy.draw(dst_surface,src_image,DrawInfos(infos,current_frame_rect,position_top_left));
 }
 
 /**

--- a/src/graphics/SpriteAnimationDirection.cpp
+++ b/src/graphics/SpriteAnimationDirection.cpp
@@ -80,7 +80,7 @@ const Rectangle& SpriteAnimationDirection::get_frame(int frame) const {
  * \param src_image the image from which the frame is extracted
  */
 void SpriteAnimationDirection::draw(Surface& dst_surface,
-    const Point& dst_position, int current_frame, Surface& src_image) {
+                                    const Point& dst_position, int current_frame, Surface& src_image, const Drawable::DrawProxy& proxy) const {
 
   const Rectangle& current_frame_rect = get_frame(current_frame);
 
@@ -88,11 +88,12 @@ void SpriteAnimationDirection::draw(Surface& dst_surface,
   Point position_top_left = dst_position;
   position_top_left -= origin;
 
-  src_image.draw_region(
-      current_frame_rect,
-      std::static_pointer_cast<Surface>(dst_surface.shared_from_this()),
-      position_top_left
-  );
+  src_image.raw_draw_region(
+        current_frame_rect,
+        dst_surface,
+        position_top_left,
+        proxy
+        );
 }
 
 /**
@@ -118,7 +119,6 @@ void SpriteAnimationDirection::enable_pixel_collisions(Surface& src_image) {
  * \brief Disables the pixel-perfect collision ability of this sprite animation direction.
  */
 void SpriteAnimationDirection::disable_pixel_collisions() {
-
   pixel_bits.clear();
 }
 

--- a/src/graphics/SpriteAnimationDirection.cpp
+++ b/src/graphics/SpriteAnimationDirection.cpp
@@ -78,6 +78,7 @@ const Rectangle& SpriteAnimationDirection::get_frame(int frame) const {
  * (the origin point will be drawn at this position)
  * \param current_frame the frame to show
  * \param src_image the image from which the frame is extracted
+ * \param infos draw info bundle
  */
 void SpriteAnimationDirection::draw(Surface& dst_surface,
                                     const Point& dst_position, int current_frame, Surface& src_image, const DrawInfos &infos) const {

--- a/src/graphics/Surface.cpp
+++ b/src/graphics/Surface.cpp
@@ -40,8 +40,8 @@ namespace Solarus {
 
 Surface::SurfaceDraw Surface::draw_proxy;
 
-void Surface::SurfaceDraw::draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const {
-  dst_surface.request_render().draw_region_other(region,src_surface.get_internal_surface(),destination);
+void Surface::SurfaceDraw::draw(Surface& dst_surface, Surface& src_surface, const DrawInfos &params) const {
+  dst_surface.request_render().draw_region_other(params,src_surface.get_internal_surface(),destination);
 }
 
 /**

--- a/src/graphics/Surface.cpp
+++ b/src/graphics/Surface.cpp
@@ -37,6 +37,13 @@
 
 namespace Solarus {
 
+
+Surface::SurfaceDraw Surface::draw_proxy;
+
+void Surface::SurfaceDraw::draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const {
+  dst_surface.request_render().draw_region_other(region,src_surface.get_internal_surface(),destination);
+}
+
 /**
  * \brief Creates a surface with the specified size.
  * \param width The width in pixels.
@@ -377,8 +384,10 @@ void Surface::fill_with_color(const Color& color, const Rectangle& where) {
  * \param dst_surface The destination surface.
  * \param dst_position Coordinates on the destination surface.
  */
-void Surface::raw_draw(Surface& dst_surface, const Point& dst_position) {
-  dst_surface.request_render().draw_other(*internal_surface,dst_position);
+void Surface::raw_draw(Surface& dst_surface, const Point& dst_position,
+                       const DrawProxy& proxy) {
+  //dst_surface.request_render().draw_other(*internal_surface,dst_position);
+  raw_draw_region(Rectangle(get_size()),dst_surface,dst_position,proxy);
 }
 
 /**
@@ -387,11 +396,11 @@ void Surface::raw_draw(Surface& dst_surface, const Point& dst_position) {
  * \param dst_surface The destination surface.
  * \param dst_position Coordinates on the destination surface.
  */
-void Surface::raw_draw_region(
-    const Rectangle& region,
+void Surface::raw_draw_region(const Rectangle& region,
     Surface& dst_surface,
-    const Point& dst_position) {
-  dst_surface.request_render().draw_region_other(region,*internal_surface,dst_position);
+    const Point& dst_position, const DrawProxy &proxy) {
+  proxy.draw(dst_surface,*this,region,dst_position);
+  //dst_surface.request_render().draw_region_other(region,*internal_surface,dst_position);
 }
 
 /**
@@ -438,9 +447,9 @@ void Surface::shader_draw_region(
  * \brief Draws a transition effect on this drawable object.
  * \param transition The transition effect to apply.
  */
-void Surface::draw_transition(Transition& transition) {
+/*void Surface::draw_transition(Transition& transition) {
   transition.draw(*this);
-}
+}*/
 
 /**
  * \brief Draws this software surface with a pixel filter on another software
@@ -488,9 +497,9 @@ void Surface::apply_pixel_filter(
  * are applied.
  * \return The surface for transitions.
  */
-Surface& Surface::get_transition_surface() {
+/*Surface& Surface::get_transition_surface() {
   return *this;
-}
+}*/
 
 /**
  * \brief Returns a pixel value of this surface.

--- a/src/graphics/Surface.cpp
+++ b/src/graphics/Surface.cpp
@@ -40,8 +40,8 @@ namespace Solarus {
 
 Surface::SurfaceDraw Surface::draw_proxy;
 
-void Surface::SurfaceDraw::draw(Surface& dst_surface, Surface& src_surface, const Rectangle& region, const Point& destination) const {
-  dst_surface.request_render().draw_region_other(region,src_surface.get_internal_surface(),destination);
+void Surface::SurfaceDraw::draw(Surface& dst_surface, const Surface &src_surface, const DrawInfos &params) const {
+  dst_surface.request_render().draw_other(src_surface.get_internal_surface(),params);
 }
 
 /**
@@ -51,7 +51,6 @@ void Surface::SurfaceDraw::draw(Surface& dst_surface, Surface& src_surface, cons
  */
 Surface::Surface(int width, int height, bool premultiplied):
   Drawable(),
-  opacity(255),
   internal_surface(nullptr)
 {
 
@@ -64,8 +63,7 @@ Surface::Surface(int width, int height, bool premultiplied):
 }
 
 Surface::Surface(SDL_Surface *surf, bool premultiplied)
-  : opacity(255),
-    internal_surface(new Texture(surf))
+  : internal_surface(new Texture(surf))
 {
   internal_surface->set_premultiplied(premultiplied);
   internal_surface->_parent = this;
@@ -82,7 +80,6 @@ Surface::Surface(SDL_Surface *surf, bool premultiplied)
  */
 Surface::Surface(SurfaceImpl* impl, bool premultiplied):
   Drawable(),
-  opacity(255),
   internal_surface(impl) //TODO refactor this...
 {
   internal_surface->set_premultiplied(premultiplied);
@@ -228,22 +225,6 @@ Size Surface::get_size() const {
 }
 
 /**
- * \brief Returns the opacity of this surface.
- * \return The opacity (0 to 255).
- */
-uint8_t Surface::get_opacity() const {
-  return opacity;
-}
-
-/**
- * \brief Sets the opacity of this surface.
- * \param opacity The opacity (0 to 255).
- */
-void Surface::set_opacity(uint8_t opacity) {
-  this->opacity = opacity;
-}
-
-/**
  * \brief Returns the SDL surface wrapped.
  * \return The internal SDL surface.
  */
@@ -384,72 +365,13 @@ void Surface::fill_with_color(const Color& color, const Rectangle& where) {
  * \param dst_surface The destination surface.
  * \param dst_position Coordinates on the destination surface.
  */
-void Surface::raw_draw(Surface& dst_surface, const Point& dst_position,
-                       const DrawProxy& proxy) {
-  //dst_surface.request_render().draw_other(*internal_surface,dst_position);
-  raw_draw_region(Rectangle(get_size()),dst_surface,dst_position,proxy);
+void Surface::raw_draw(Surface& dst_surface, const DrawInfos& infos) const {
+  infos.proxy.draw(dst_surface,*this,infos);
 }
 
-/**
- * \brief Draws a subrectangle of this surface on another surface.
- * \param region The subrectangle to draw in this object.
- * \param dst_surface The destination surface.
- * \param dst_position Coordinates on the destination surface.
- */
-void Surface::raw_draw_region(const Rectangle& region,
-    Surface& dst_surface,
-    const Point& dst_position, const DrawProxy &proxy) {
-  proxy.draw(dst_surface,*this,region,dst_position);
-  //dst_surface.request_render().draw_region_other(region,*internal_surface,dst_position);
+Rectangle Surface::get_region() const {
+  return Rectangle(Point(), get_size());
 }
-
-/**
- * \brief Draws this surface on another surface, using the given shader
- * \param shader The shader
- * \param dst_surface The destination surface.
- * \param dst_position Coordinates on the destination surface.
- */
-void Surface::shader_draw(
-    const ShaderPtr& shader,
-    Surface& dst_surface,
-    const Point& dst_position
-    ) {
-  shader_draw_region(shader,Rectangle(get_size()),dst_surface,dst_position);
-}
-
-/**
- * \brief Draws a subrectangle of this surface on another surface, using the given shader
- * \param shader The shader
- * \param region The subrectangle to draw in this object.
- * \param dst_surface The destination surface.
- * \param dst_position Coordinates on the destination surface.
- */
-void Surface::shader_draw_region(
-    const ShaderPtr& shader,
-    const Rectangle& region,
-    Surface& dst_surface,
-    const Point& dst_position
-    ) {
-  dst_surface.request_render().with_target([&](SDL_Renderer* r){
-    SDL_BlendMode target = get_sdl_blend_mode();
-    SDL_BlendMode current;
-    SDL_GetRenderDrawBlendMode(r,&current);
-    if(target != current) { //Blend mode need change
-      SDL_SetRenderDrawBlendMode(r,get_sdl_blend_mode());
-      SDL_RenderDrawPoint(r,-100,-100); //Draw a point offscreen to force blendmode change
-    }
-    shader->set_uniform_1f("sol_opacity",get_opacity()/256.f);
-    shader->render(*this,region,dst_surface.get_size(),dst_position);
-  });
-}
-
-/**
- * \brief Draws a transition effect on this drawable object.
- * \param transition The transition effect to apply.
- */
-/*void Surface::draw_transition(Transition& transition) {
-  transition.draw(*this);
-}*/
 
 /**
  * \brief Draws this software surface with a pixel filter on another software
@@ -588,28 +510,48 @@ uint32_t Surface::get_color_value(const Color& color) const {
   return SDL_MapRGBA(Video::get_pixel_format(), r, g, b, a);
 }
 
-/**
- * \brief Returns the blend mode as an SDL_BlendMode value.
- * \return The blend mode.
- */
-SDL_BlendMode Surface::get_sdl_blend_mode() const {
 
-  switch (get_blend_mode()) {
-
-  case BlendMode::NONE:
-    return SDL_BLENDMODE_NONE;
-
-  case BlendMode::BLEND:
-    return SDL_BLENDMODE_BLEND;
-
-  case BlendMode::ADD:
-    return SDL_BLENDMODE_ADD;
-
-  case BlendMode::MULTIPLY:
-    return SDL_BLENDMODE_MOD;
+SDL_BlendMode Surface::make_sdl_blend_mode(const SurfaceImpl& dst_surface, const SurfaceImpl& src_surface, BlendMode blend_mode) {
+  if(dst_surface.is_premultiplied()) {
+    switch(blend_mode) {
+      case BlendMode::NONE:
+        return SDL_BLENDMODE_NONE;
+      case BlendMode::MULTIPLY:
+        return SDL_BLENDMODE_MOD;
+      case BlendMode::ADD:
+        return SDL_BLENDMODE_ADD;
+      case BlendMode::BLEND:
+      default:
+        return SDL_ComposeCustomBlendMode(
+              SDL_BLENDFACTOR_SRC_ALPHA,
+              SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+              SDL_BLENDOPERATION_ADD,
+              SDL_BLENDFACTOR_ONE,
+              SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+              SDL_BLENDOPERATION_ADD);
+    }
+  } else {
+    //Straight destination
+    if(src_surface.is_premultiplied() && blend_mode == BlendMode::BLEND)
+      return SDL_ComposeCustomBlendMode(
+            SDL_BLENDFACTOR_ONE,
+            SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+            SDL_BLENDOPERATION_ADD,
+            SDL_BLENDFACTOR_ONE,
+            SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+            SDL_BLENDOPERATION_ADD);
+    switch(blend_mode) { //TODO check other modes
+      case BlendMode::NONE:
+        return SDL_BLENDMODE_NONE;
+      case BlendMode::MULTIPLY:
+        return SDL_BLENDMODE_MOD;
+      case BlendMode::ADD:
+        return SDL_BLENDMODE_ADD;
+      case BlendMode::BLEND:
+      default:
+        return SDL_BLENDMODE_BLEND;
+    }
   }
-
-  return SDL_BLENDMODE_BLEND;
 }
 
 /**

--- a/src/graphics/SurfaceImpl.cpp
+++ b/src/graphics/SurfaceImpl.cpp
@@ -12,9 +12,6 @@ void SurfaceImpl::upload_surface() {
                     );
 }
 
-const Surface& SurfaceImpl::parent() const {
-    return *_parent;
-}
 
 SurfaceImpl::~SurfaceImpl() {
 

--- a/src/graphics/TextSurface.cpp
+++ b/src/graphics/TextSurface.cpp
@@ -539,11 +539,11 @@ void TextSurface::rebuild_ttf() {
  * \param dst_position Coordinates on the destination surface.
  */
 void TextSurface::raw_draw(Surface& dst_surface,
-    const Point& dst_position) {
+    const Point& dst_position, const DrawProxy &proxy) {
 
   if (surface != nullptr) {
     surface->set_blend_mode(get_blend_mode());
-    surface->raw_draw(dst_surface, dst_position + text_position);
+    surface->raw_draw(dst_surface, dst_position + text_position, proxy);
   }
 }
 
@@ -554,13 +554,13 @@ void TextSurface::raw_draw(Surface& dst_surface,
  * \param dst_position Coordinates on the destination surface.
  */
 void TextSurface::raw_draw_region(const Rectangle& region,
-    Surface& dst_surface, const Point& dst_position) {
+    Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) {
 
   if (surface != nullptr) {
     surface->set_blend_mode(get_blend_mode());
     surface->raw_draw_region(
         region, dst_surface,
-        dst_position + text_position);
+        dst_position + text_position, proxy);
   }
 }
 
@@ -590,7 +590,7 @@ void TextSurface::shader_draw_region(
  * \brief Draws a transition effect on this drawable object.
  * \param transition The transition effect to apply.
  */
-void TextSurface::draw_transition(Transition& transition) {
+/*void TextSurface::draw_transition(Transition& transition) {
   transition.draw(*surface);
 }
 
@@ -599,9 +599,9 @@ void TextSurface::draw_transition(Transition& transition) {
  * are applied.
  * \return The surface for transitions.
  */
-Surface& TextSurface::get_transition_surface() {
+/*Surface& TextSurface::get_transition_surface() {
   return *surface;
-}
+}*/
 
 /**
  * \brief Returns the name identifying this type in Lua.

--- a/src/graphics/TextSurface.cpp
+++ b/src/graphics/TextSurface.cpp
@@ -529,35 +529,28 @@ void TextSurface::rebuild_ttf() {
 }
 
 /**
- * \brief Draws the text on a surface.
- *
- * This method blits the text at the position previously set
- * (by set_x(), set_y() or set_position())
- * plus the parameter dst_position.
- *
+ * \brief Draws this text on the given surface
+ * \param region The subrectangle to draw in this object.
  * \param dst_surface The destination surface.
- * \param dst_position Coordinates on the destination surface.
+ * \param infos draw informations.
  */
-/*void TextSurface::raw_draw(Surface& dst_surface,
-    const Point& dst_position, const DrawInfos &infos) {
-
+void TextSurface::raw_draw(Surface& dst_surface,const DrawInfos& infos) const {
   if (surface != nullptr) {
-    surface->set_blend_mode(get_blend_mode());
-    surface->raw_draw(dst_surface, dst_position + text_position, infos);
+    surface->raw_draw(
+        dst_surface,
+        DrawInfos(infos,infos.dst_position + text_position));
   }
-}*/
+}
 
 /**
  * \brief Draws a subrectangle of this text surface on another surface.
  * \param region The subrectangle to draw in this object.
  * \param dst_surface The destination surface.
- * \param dst_position Coordinates on the destination surface.
+ * \param infos drawing infos
  */
-void TextSurface::raw_draw(Surface& dst_surface,const DrawInfos& infos) const {
-
+void TextSurface::raw_draw_region(Surface& dst_surface,const DrawInfos& infos) const {
   if (surface != nullptr) {
-    //surface->set_blend_mode(get_blend_mode()); //TODO remove
-    surface->raw_draw(
+    surface->raw_draw_region(
         dst_surface,
         DrawInfos(infos,infos.dst_position + text_position));
   }
@@ -566,45 +559,6 @@ void TextSurface::raw_draw(Surface& dst_surface,const DrawInfos& infos) const {
 Rectangle TextSurface::get_region() const {
   return Rectangle(Point(),get_size());
 }
-
-/*void TextSurface::shader_draw(
-    const ShaderPtr& shader,
-    Surface& dst_surface,
-    const Point& dst_position
-    ) {
-  if (surface != nullptr) {
-    shader_draw_region(shader,Rectangle(surface->get_size()),dst_surface,dst_position);
-  }
-}
-
-void TextSurface::shader_draw_region(
-    const ShaderPtr& shader,
-    const Rectangle& region,
-    Surface& dst_surface,
-    const Point& dst_position
-    ) {
-  if (surface != nullptr) {
-    surface->set_blend_mode(get_blend_mode());
-    surface->shader_draw_region(shader,region,dst_surface,dst_position);
-  }
-}
-*/
-/**
- * \brief Draws a transition effect on this drawable object.
- * \param transition The transition effect to apply.
- */
-/*void TextSurface::draw_transition(Transition& transition) {
-  transition.draw(*surface);
-}
-
-/**
- * \brief Returns the surface where transitions on this drawable object
- * are applied.
- * \return The surface for transitions.
- */
-/*Surface& TextSurface::get_transition_surface() {
-  return *surface;
-}*/
 
 /**
  * \brief Returns the name identifying this type in Lua.

--- a/src/graphics/TextSurface.cpp
+++ b/src/graphics/TextSurface.cpp
@@ -538,14 +538,14 @@ void TextSurface::rebuild_ttf() {
  * \param dst_surface The destination surface.
  * \param dst_position Coordinates on the destination surface.
  */
-void TextSurface::raw_draw(Surface& dst_surface,
-    const Point& dst_position, const DrawProxy &proxy) {
+/*void TextSurface::raw_draw(Surface& dst_surface,
+    const Point& dst_position, const DrawInfos &infos) {
 
   if (surface != nullptr) {
     surface->set_blend_mode(get_blend_mode());
-    surface->raw_draw(dst_surface, dst_position + text_position, proxy);
+    surface->raw_draw(dst_surface, dst_position + text_position, infos);
   }
-}
+}*/
 
 /**
  * \brief Draws a subrectangle of this text surface on another surface.
@@ -553,18 +553,21 @@ void TextSurface::raw_draw(Surface& dst_surface,
  * \param dst_surface The destination surface.
  * \param dst_position Coordinates on the destination surface.
  */
-void TextSurface::raw_draw_region(const Rectangle& region,
-    Surface& dst_surface, const Point& dst_position, const DrawProxy& proxy) {
+void TextSurface::raw_draw(Surface& dst_surface,const DrawInfos& infos) const {
 
   if (surface != nullptr) {
-    surface->set_blend_mode(get_blend_mode());
-    surface->raw_draw_region(
-        region, dst_surface,
-        dst_position + text_position, proxy);
+    //surface->set_blend_mode(get_blend_mode()); //TODO remove
+    surface->raw_draw(
+        dst_surface,
+        DrawInfos(infos,infos.dst_position + text_position));
   }
 }
 
-void TextSurface::shader_draw(
+Rectangle TextSurface::get_region() const {
+  return Rectangle(Point(),get_size());
+}
+
+/*void TextSurface::shader_draw(
     const ShaderPtr& shader,
     Surface& dst_surface,
     const Point& dst_position
@@ -585,7 +588,7 @@ void TextSurface::shader_draw_region(
     surface->shader_draw_region(shader,region,dst_surface,dst_position);
   }
 }
-
+*/
 /**
  * \brief Draws a transition effect on this drawable object.
  * \param transition The transition effect to apply.

--- a/src/graphics/Texture.cpp
+++ b/src/graphics/Texture.cpp
@@ -51,7 +51,9 @@ int Texture::get_height() const {
  */
 RenderTexture* Texture::to_render_texture() {
     RenderTexture* rt = new RenderTexture(get_width(),get_height());
-    rt->draw_other(*this,Point(0,0));
+    rt->draw_other(*this,DrawInfos(Rectangle(Point(),Size(get_width(),get_height())),
+                                   Point(),
+                                   BlendMode::NONE,255,Surface::draw_proxy));
     return rt;
 }
 

--- a/src/graphics/Transition.cpp
+++ b/src/graphics/Transition.cpp
@@ -62,7 +62,6 @@ Transition::~Transition() {
 Transition* Transition::create(
     Transition::Style style,
     Transition::Direction direction,
-    Surface& dst_surface,
     Game* game) {
 
   Transition* transition = nullptr;

--- a/src/graphics/Transition.cpp
+++ b/src/graphics/Transition.cpp
@@ -74,7 +74,7 @@ Transition* Transition::create(
     break;
 
   case Style::FADE:
-    transition = new TransitionFade(direction, dst_surface);
+    transition = new TransitionFade(direction);
     break;
 
   case Style::SCROLLING:

--- a/src/graphics/TransitionFade.cpp
+++ b/src/graphics/TransitionFade.cpp
@@ -173,21 +173,21 @@ void TransitionFade::update() {
  * \brief Draws the transition effect on a surface.
  * \param dst_surface The destination surface.
  */
-void TransitionFade::draw(Surface& dst_surface, Surface &src_surface, const Rectangle &region, const Point &destination) const { //TODO fix this
+void TransitionFade::draw(Surface& dst_surface, Surface &src_surface, const DrawInfos &params) const { //TODO fix this
   // Draw the transition effect on the surface.
   int alpha_impl = std::min(alpha, 255);
 
   if (!colored) {
     // Set the opacity on the surface.
     src_surface.set_opacity(alpha_impl);
-    src_surface.raw_draw_region(region,dst_surface,destination,Surface::draw_proxy);
+    src_surface.raw_draw_region(params,dst_surface,destination,Surface::draw_proxy);
   } else {
     // Add a colored foreground surface with the appropriate opacity.
     uint8_t r, g, b, a;
     transition_color.get_components(r, g, b, a);
     // A full opaque transition corresponds to a foreground with full alpha.
     Color fade_color(r, g, b, 255 - std::min(alpha_impl, (int) a));
-    src_surface.raw_draw_region(region,dst_surface,destination,Surface::draw_proxy);
+    src_surface.raw_draw_region(params,dst_surface,destination,Surface::draw_proxy);
     dst_surface.fill_with_color(fade_color);
   }
 

--- a/src/graphics/TransitionFade.cpp
+++ b/src/graphics/TransitionFade.cpp
@@ -30,12 +30,11 @@ namespace Solarus {
  * \param dst_surface The destination surface that will receive this
  * transition.
  */
-TransitionFade::TransitionFade(Direction direction, Surface& dst_surface):
+TransitionFade::TransitionFade(Direction direction):
   Transition(direction),
   finished(false),
   alpha(-1),
   next_frame_date(0),
-  dst_surface(&dst_surface),
   colored(true),
   transition_color(Color::black) {
 
@@ -174,26 +173,26 @@ void TransitionFade::update() {
  * \brief Draws the transition effect on a surface.
  * \param dst_surface The destination surface.
  */
-void TransitionFade::draw(Surface& dst_surface) {
-
+void TransitionFade::draw(Surface& dst_surface, Surface &src_surface, const Rectangle &region, const Point &destination) const { //TODO fix this
   // Draw the transition effect on the surface.
   int alpha_impl = std::min(alpha, 255);
 
   if (!colored) {
     // Set the opacity on the surface.
-    dst_surface.set_opacity(alpha_impl);
-  }
-  else {
+    src_surface.set_opacity(alpha_impl);
+    src_surface.raw_draw_region(region,dst_surface,destination,Surface::draw_proxy);
+  } else {
     // Add a colored foreground surface with the appropriate opacity.
     uint8_t r, g, b, a;
     transition_color.get_components(r, g, b, a);
     // A full opaque transition corresponds to a foreground with full alpha.
     Color fade_color(r, g, b, 255 - std::min(alpha_impl, (int) a));
-
+    src_surface.raw_draw_region(region,dst_surface,destination,Surface::draw_proxy);
     dst_surface.fill_with_color(fade_color);
   }
 
-  this->dst_surface = &dst_surface;
+  //this->dst_surface = &dst_surface;
+
 }
 
 }

--- a/src/graphics/TransitionFade.cpp
+++ b/src/graphics/TransitionFade.cpp
@@ -173,26 +173,26 @@ void TransitionFade::update() {
  * \brief Draws the transition effect on a surface.
  * \param dst_surface The destination surface.
  */
-void TransitionFade::draw(Surface& dst_surface, Surface &src_surface, const Rectangle &region, const Point &destination) const { //TODO fix this
+void TransitionFade::draw(Surface& dst_surface, const Surface &src_surface, const DrawInfos &infos) const { //TODO fix this
   // Draw the transition effect on the surface.
-  int alpha_impl = std::min(alpha, 255);
+  int alpha_impl = std::min((alpha*infos.opacity)/256, 255); //TODO fix alpha not being retained...
 
   if (!colored) {
-    // Set the opacity on the surface.
-    src_surface.set_opacity(alpha_impl);
-    src_surface.raw_draw_region(region,dst_surface,destination,Surface::draw_proxy);
+    // Draw surface with modified opacity
+    infos.proxy.draw(dst_surface,src_surface,DrawInfos(infos,(uint8_t)alpha_impl));
   } else {
     // Add a colored foreground surface with the appropriate opacity.
     uint8_t r, g, b, a;
     transition_color.get_components(r, g, b, a);
     // A full opaque transition corresponds to a foreground with full alpha.
     Color fade_color(r, g, b, 255 - std::min(alpha_impl, (int) a));
-    src_surface.raw_draw_region(region,dst_surface,destination,Surface::draw_proxy);
+    infos.proxy.draw(dst_surface,src_surface,infos);
     dst_surface.fill_with_color(fade_color);
   }
+}
 
-  //this->dst_surface = &dst_surface;
-
+void TransitionFade::finish(Drawable& target) const {
+  target.set_opacity(std::min((alpha*target.get_opacity())/256,255));
 }
 
 }

--- a/src/graphics/TransitionImmediate.cpp
+++ b/src/graphics/TransitionImmediate.cpp
@@ -69,8 +69,8 @@ void TransitionImmediate::update() {
  * \brief Draws the transition effect on a surface.
  * \param dst_surface the surface to draw
  */
-void TransitionImmediate::draw(Surface& dst_surface, Surface &src_surface, const Rectangle& region, const Point& destination) const {
-  Surface::draw_proxy.draw(dst_surface,src_surface,region,destination);
+void TransitionImmediate::draw(Surface& dst_surface, const Surface &src_surface, const DrawInfos &infos) const {
+  infos.proxy.draw(dst_surface,src_surface,infos);
 }
 
 }

--- a/src/graphics/TransitionImmediate.cpp
+++ b/src/graphics/TransitionImmediate.cpp
@@ -15,6 +15,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 #include "solarus/graphics/TransitionImmediate.h"
+#include "solarus/graphics/Surface.h"
 
 namespace Solarus {
 
@@ -68,8 +69,8 @@ void TransitionImmediate::update() {
  * \brief Draws the transition effect on a surface.
  * \param dst_surface the surface to draw
  */
-void TransitionImmediate::draw(Surface& /* dst_surface */) {
-
+void TransitionImmediate::draw(Surface& dst_surface, Surface &src_surface, const Rectangle& region, const Point& destination) const {
+  Surface::draw_proxy.draw(dst_surface,src_surface,region,destination);
 }
 
 }

--- a/src/graphics/TransitionScrolling.cpp
+++ b/src/graphics/TransitionScrolling.cpp
@@ -31,7 +31,6 @@ namespace Solarus {
  */
 TransitionScrolling::TransitionScrolling(Transition::Direction direction):
   Transition(direction),
-  both_maps_surface(nullptr),
   scrolling_direction(0),
   next_scroll_date(0),
   dx(0),
@@ -97,9 +96,6 @@ void TransitionScrolling::start() {
     height *= 2;
     dy = (scrolling_direction == 3) ? scrolling_step : -scrolling_step;
   }
-
-  // create a surface with the two maps
-  both_maps_surface = Surface::create(width, height);
 
   // set the blitting rectangles
 
@@ -209,7 +205,7 @@ void TransitionScrolling::update() {
  * \brief Draws the transition effect on a surface.
  * \param dst_surface the surface to draw
  */
-void TransitionScrolling::draw(Surface& dst_surface) {
+void TransitionScrolling::draw(Surface& dst_surface, Surface &src_surface, const Rectangle &region, const Point &destination) const { //TODO fix
 
   if (get_direction() == Direction::CLOSING) {
     return;
@@ -220,16 +216,9 @@ void TransitionScrolling::draw(Surface& dst_surface) {
       "No previous surface defined for scrolling");
 
   // draw the old map
-  previous_surface->draw(both_maps_surface, previous_map_dst_position.get_xy());
+  previous_surface->raw_draw(dst_surface, previous_map_dst_position.get_xy()-current_scrolling_position.get_xy());
 
   // draw the new map
-  dst_surface.draw(both_maps_surface, current_map_dst_position.get_xy());
-
-  // blit both surfaces
-  both_maps_surface->draw_region(
-      current_scrolling_position,
-      std::static_pointer_cast<Surface>(dst_surface.shared_from_this())
-  );
+  src_surface.raw_draw(dst_surface, current_map_dst_position.get_xy()-current_scrolling_position.get_xy());
 }
-
 }

--- a/src/graphics/TransitionScrolling.cpp
+++ b/src/graphics/TransitionScrolling.cpp
@@ -205,7 +205,7 @@ void TransitionScrolling::update() {
  * \brief Draws the transition effect on a surface.
  * \param dst_surface the surface to draw
  */
-void TransitionScrolling::draw(Surface& dst_surface, Surface &src_surface, const Rectangle &region, const Point &destination) const { //TODO fix
+void TransitionScrolling::draw(Surface& dst_surface, const Surface &src_surface, const DrawInfos &infos) const {
 
   if (get_direction() == Direction::CLOSING) {
     return;
@@ -216,9 +216,15 @@ void TransitionScrolling::draw(Surface& dst_surface, Surface &src_surface, const
       "No previous surface defined for scrolling");
 
   // draw the old map
-  previous_surface->raw_draw(dst_surface, previous_map_dst_position.get_xy()-current_scrolling_position.get_xy());
+  infos.proxy.draw(dst_surface,*previous_surface,
+                   DrawInfos(infos,
+                             Rectangle(Point(),previous_surface->get_size()),
+                             previous_map_dst_position.get_xy()-current_scrolling_position.get_xy()));
 
   // draw the new map
-  src_surface.raw_draw(dst_surface, current_map_dst_position.get_xy()-current_scrolling_position.get_xy());
+  infos.proxy.draw(dst_surface,src_surface,
+                   DrawInfos(infos,
+                             Rectangle(Point(),src_surface.get_size()),
+                             current_map_dst_position.get_xy()-current_scrolling_position.get_xy()));
 }
 }

--- a/src/lua/DrawableApi.cpp
+++ b/src/lua/DrawableApi.cpp
@@ -269,8 +269,7 @@ int LuaContext::drawable_api_fade_in(lua_State* l) {
     }
 
     TransitionFade* transition(new TransitionFade(
-        Transition::Direction::OPENING,
-        drawable.get_transition_surface()
+        Transition::Direction::OPENING
     ));
     transition->clear_color();
     transition->set_delay(delay);
@@ -308,8 +307,7 @@ int LuaContext::drawable_api_fade_out(lua_State* l) {
     }
 
     TransitionFade* transition(new TransitionFade(
-        Transition::Direction::CLOSING,
-        drawable.get_transition_surface()
+        Transition::Direction::CLOSING
     ));
     transition->clear_color();
     transition->set_delay(delay);


### PR DESCRIPTION
Removes most of the engine-defined intermediates surfaces that were used to achieve transitions and that were, because 2D acceleration changes, the new bottleneck of the draw system.

A concept of DrawProxy is introduced, which controls how surfaces are drawn. These allow to merge all drawing paths, including shaders.

At the price of some uglyness in Shader::draw, we gain full constness in Drawable::draw... can be debated.