### PR TITLE
Fixed camera misdrawn when not at (0,0)

### DIFF
--- a/src/core/Game.cpp
+++ b/src/core/Game.cpp
@@ -575,8 +575,8 @@ void Game::draw(const SurfacePtr& dst_surface) {
     if (camera != nullptr) {
       const SurfacePtr& camera_surface = camera->get_surface();
       if (transition != nullptr) {
-        transition->draw(*dst_surface,*camera_surface,DrawInfos(Rectangle(camera_surface->get_size()),Point(),BlendMode::BLEND,255,Surface::draw_proxy));
-      } else { //TODO handle this case
+        transition->draw(*dst_surface,*camera_surface,DrawInfos(Rectangle(camera_surface->get_size()),camera->get_position_on_screen(),BlendMode::BLEND,255,Surface::draw_proxy));
+      } else {
         camera_surface->draw(dst_surface, camera->get_position_on_screen());
       }
     }


### PR DESCRIPTION
This fixes the bug in the intro of Zelda MS XD2.