### PR TITLE
Version independent default shaders

### DIFF
--- a/src/graphics/GlArbShader.cpp
+++ b/src/graphics/GlArbShader.cpp
@@ -36,17 +36,29 @@ namespace Solarus {
 
 constexpr auto DEFAULT_VERTEX =
     R"(
-    #version 100
+    #if __VERSION__ >= 130
+    #define COMPAT_VARYING out
+    #define COMPAT_ATTRIBUTE in
+    #else
+    #define COMPAT_VARYING varying
+    #define COMPAT_ATTRIBUTE attribute
+    #endif
+
+    #ifdef GL_ES
     precision mediump float;
+    #define COMPAT_PRECISION mediump
+    #else
+    #define COMPAT_PRECISION
+    #endif
 
     uniform mat4 sol_mvp_matrix;
     uniform mat3 sol_uv_matrix;
-    attribute vec2 sol_vertex;
-    attribute vec2 sol_tex_coord;
-    attribute vec4 sol_color;
+    COMPAT_ATTRIBUTE vec2 sol_vertex;
+    COMPAT_ATTRIBUTE vec2 sol_tex_coord;
+    COMPAT_ATTRIBUTE vec4 sol_color;
 
-    varying vec2 sol_vtex_coord;
-    varying vec4 sol_vcolor;
+    COMPAT_VARYING vec2 sol_vtex_coord;
+    COMPAT_VARYING vec4 sol_vcolor;
     void main() {
       gl_Position = sol_mvp_matrix * vec4(sol_vertex,0,1);
       sol_vcolor = sol_color;
@@ -56,17 +68,31 @@ constexpr auto DEFAULT_VERTEX =
 
 constexpr auto DEFAULT_FRAGMENT =
     R"(
-    #version 100
+    #if __VERSION__ >= 130
+    #define COMPAT_VARYING in
+    #define COMPAT_TEXTURE texture
+    out vec4 FragColor;
+    #else
+    #define COMPAT_VARYING varying
+    #define FragColor gl_FragColor
+    #define COMPAT_TEXTURE texture2D
+    #endif
+
+    #ifdef GL_ES
     precision mediump float;
+    #define COMPAT_PRECISION mediump
+    #else
+    #define COMPAT_PRECISION
+    #endif
+
     uniform sampler2D sol_texture;
-    varying vec2 sol_vtex_coord;
-    varying vec4 sol_vcolor;
+    COMPAT_VARYING vec2 sol_vtex_coord;
+    COMPAT_VARYING vec4 sol_vcolor;
     void main() {
-      vec4 tex_color = texture2D(sol_texture,sol_vtex_coord);
-      gl_FragColor = tex_color*sol_vcolor;
+      vec4 tex_color = COMPAT_TEXTURE(sol_texture,sol_vtex_coord);
+      FragColor = tex_color*sol_vcolor;
     }
     )";
-
 
 namespace {
 

--- a/src/graphics/GlShader.cpp
+++ b/src/graphics/GlShader.cpp
@@ -35,34 +35,61 @@ namespace Solarus {
 
 constexpr auto DEFAULT_VERTEX =
     R"(
-    #version 100
+    #if __VERSION__ >= 130
+    #define COMPAT_VARYING out
+    #define COMPAT_ATTRIBUTE in
+    #else
+    #define COMPAT_VARYING varying
+    #define COMPAT_ATTRIBUTE attribute
+    #endif
+
+    #ifdef GL_ES
     precision mediump float;
+    #define COMPAT_PRECISION mediump
+    #else
+    #define COMPAT_PRECISION
+    #endif
 
     uniform mat4 sol_mvp_matrix;
     uniform mat3 sol_uv_matrix;
-    attribute vec2 sol_vertex;
-    attribute vec2 sol_tex_coord;
-    attribute vec4 sol_color;
+    COMPAT_ATTRIBUTE vec2 sol_vertex;
+    COMPAT_ATTRIBUTE vec2 sol_tex_coord;
+    COMPAT_ATTRIBUTE vec4 sol_color;
 
-    varying vec2 sol_vtex_coord;
-    varying vec4 sol_vcolor;
+    COMPAT_VARYING vec2 sol_vtex_coord;
+    COMPAT_VARYING vec4 sol_vcolor;
     void main() {
-    gl_Position = sol_mvp_matrix * vec4(sol_vertex,0,1);
-    sol_vcolor = sol_color;
-    sol_vtex_coord = (sol_uv_matrix * vec3(sol_tex_coord,1)).xy;
+      gl_Position = sol_mvp_matrix * vec4(sol_vertex,0,1);
+      sol_vcolor = sol_color;
+      sol_vtex_coord = (sol_uv_matrix * vec3(sol_tex_coord,1)).xy;
     }
     )";
 
 constexpr auto DEFAULT_FRAGMENT =
     R"(
-    #version 100
+    #if __VERSION__ >= 130
+    #define COMPAT_VARYING in
+    #define COMPAT_TEXTURE texture
+    out vec4 FragColor;
+    #else
+    #define COMPAT_VARYING varying
+    #define FragColor gl_FragColor
+    #define COMPAT_TEXTURE texture2D
+    #endif
+
+    #ifdef GL_ES
     precision mediump float;
+    #define COMPAT_PRECISION mediump
+    #else
+    #define COMPAT_PRECISION
+    #endif
+
     uniform sampler2D sol_texture;
-    varying vec2 sol_vtex_coord;
-    varying vec4 sol_vcolor;
+    COMPAT_VARYING vec2 sol_vtex_coord;
+    COMPAT_VARYING vec4 sol_vcolor;
     void main() {
-    vec4 tex_color = texture2D(sol_texture,sol_vtex_coord);
-    gl_FragColor = tex_color*sol_vcolor;
+      vec4 tex_color = COMPAT_TEXTURE(sol_texture,sol_vtex_coord);
+      FragColor = tex_color*sol_vcolor;
     }
     )";
 


### PR DESCRIPTION
Fixes the default shaders not building on drivers not allowing `#version 100`. Uses glsl preprocessor to deduce syntax and features to use.